### PR TITLE
Numerous configuration and syntax enhancements

### DIFF
--- a/docs/chapters/acks.adoc
+++ b/docs/chapters/acks.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Acknowledgements
 
 The following Java EE community members graciously reviewed and contributed to this hands-on lab:

--- a/docs/chapters/appendix.adoc
+++ b/docs/chapters/appendix.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [appendix]
 == Appendix
 
@@ -11,7 +13,7 @@ ifdef::server-wildfly[]
 +
 . Specify the name as ``Dev Update Center'' and the URL as ``http://deadlock.netbeans.org/job/nbms-and-javadoc/lastStableBuild/artifact/nbbuild/nbms/updates.xml.gz''.
 +
-image::images/16-netbeans-add-dev-update-center.png[title="NetBeans Update Center"]
+image::16-netbeans-add-dev-update-center.png[title="NetBeans Update Center"]
 +
 and click on `OK'.
 
@@ -20,7 +22,7 @@ and click on `OK'.
 
 . In NetBeans, click on `Tools', `Plugins', `Available Plugins', type ``wildfly'' in `Search:' box, and select the plugin by clicking on the checkbox in `Install' column.
 +
-image::images/16-netbeans-available-plugins-wildfly.png[title="Available Plugins in NetBeans"]
+image::16-netbeans-available-plugins-wildfly.png[title="Available Plugins in NetBeans"]
 +
 The exact plugin version and the date may be different.
 . Click on `Install' button, `Next >', accept the license agreement by clicking on the checkbox, and click on `Install' button to install the plugin. Click on `Finish' to restart the IDE and complete installation.
@@ -31,23 +33,23 @@ The exact plugin version and the date may be different.
 +
 . Right-click on Servers, choose `Add Server...' in the pop-up menu.
 +
-image::images/netbeans-addserver.png[title="Add Server in NetBeans"]
+image::netbeans-addserver.png[title="Add Server in NetBeans"]
 +
 . Select `WildFly Application Server' in the Add Server Instance wizard, set the
 name to `WildFly 8' and click `Next >'.
 +
-image::images/16-netbeans-add-instance-wildfly.png[title="Add WildFly instance to NetBeans"]
+image::16-netbeans-add-instance-wildfly.png[title="Add WildFly instance to NetBeans"]
 +
 . Click on `Browse' for `Server Location' and select the directory that got created
 when WildFly archive was unzipped. Click on `Browse' for `Server Configuration' and
 select the `standalone/configuration/standalone-full.xml' file in the unzipped WildFly
 archive.
 +
-image::images/16-netbeans-wildfly-full-platform.png[title="Configure WildFly full instance in NetBeans"]
+image::16-netbeans-wildfly-full-platform.png[title="Configure WildFly full instance in NetBeans"]
 +
 Click on `Next' and then `Finish'. The `Services' should show the WildFly instance.
 +
-image::images/16-netbeans-wildfly-server.png[title="WildFly instance in NetBeans Services tab"]
+image::16-netbeans-wildfly-server.png[title="WildFly instance in NetBeans Services tab"]
 
 [[appendix-wildfly-idea]]
 // === Configure WildFly 8 in IntelliJ IDEA
@@ -76,27 +78,27 @@ First of all, you should specify the JDK that you are going to use. In IntelliJ 
 +
 . On the Welcome screen, under *Quick Start*, click *Configure*.
 +
-image::images/i13-welcome-configure.png[title="Welcome to IntelliJ IDEA"]
+image::i13-welcome-configure.png[title="Welcome to IntelliJ IDEA"]
 +
 . Under *Configure*, click *Project Defaults*, and then, under *Project Defaults*, click *Project Structure*.
 +
-. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image::images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JDK*.
+. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image:images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JDK*.
 +
-image::images/i13-plus-jdk.png[title="Add JDK in IntelliJ IDEA"]
+image::i13-plus-jdk.png[title="Add JDK in IntelliJ IDEA"]
 +
 . In the *Select Home Directory for JDK* dialog, select the folder in which the JDK that you are going to use is installed, and click *OK*.
 +
-image::images/i13-jdk-home.png[title="JDK home in IntelliJ IDEA"]
+image::i13-jdk-home.png[title="JDK home in IntelliJ IDEA"]
 +
 . In the *Project Structure* dialog, click *Apply*.
 +
-image::images/i13-jdk-defined.png[title="JDK defined in IntelliJ IDEA"]
+image::i13-jdk-defined.png[title="JDK defined in IntelliJ IDEA"]
 +
 Now, let's make the JDK that we have specified the default SDK.
 +
 . In the left-hand pane, under *Project Settings*, select *Project*. In the right-hand part of the dialog, under *Project SDK*, select the JDK from the list.
 +
-image::images/i13-project-sdk.png[title="Project SDK in IntelliJ IDEA"]
+image::i13-project-sdk.png[title="Project SDK in IntelliJ IDEA"]
 +
 . Click *OK*.
 
@@ -105,64 +107,64 @@ image::images/i13-project-sdk.png[title="Project SDK in IntelliJ IDEA"]
 
 Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On Mac OS, this dialog is called *Preferences*.)
 
-. On the Welcome screen, to the left of *Project Defaults*, click *Back* image::images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
+. On the Welcome screen, to the left of *Project Defaults*, click *Back* image:images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
 +
 . Under *Configure*, click *Settings*.
 +
-. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image::images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JBoss Server*. (WildFly is a server from the "JBoss family".)
+. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image:images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JBoss Server*. (WildFly is a server from the "JBoss family".)
 +
-image::images/i13-plus-jboss.png[title="Add WildFly in IntelliJ IDEA"]
+image::i13-plus-jboss.png[title="Add WildFly in IntelliJ IDEA"]
 +
-. In the *JBoss Server* dialog, click image::images/i13-ellipsis-button.png[title="Ellipsis button in IntelliJ IDEA"] to the right of the *JBoss Home* field.
+. In the *JBoss Server* dialog, click image:images/i13-ellipsis-button.png[title="Ellipsis button in IntelliJ IDEA"] to the right of the *JBoss Home* field.
 +
-image::images/i13-jboss-server-dialog-initial.png[title="WildFly server dialog in IntelliJ IDEA"]
+image::i13-jboss-server-dialog-initial.png[title="WildFly server dialog in IntelliJ IDEA"]
 +
 . In the *JBoss Home Directory* dialog, select the folder in which you have the WildFly server installed, and click *OK*.
 +
-image::images/i13-jboss-home-directory.png[title="WildFly home in IntelliJ IDEA"]
+image::i13-jboss-home-directory.png[title="WildFly home in IntelliJ IDEA"]
 +
 . Click *OK* in the *JBoss Server* dialog.
 +
-image::images/i13-jboss-server-dialog-final.png[title="WildFly final dialog in IntelliJ IDEA"]
+image::i13-jboss-server-dialog-final.png[title="WildFly final dialog in IntelliJ IDEA"]
 +
 . In the *Settings* (*Preferences*) dialog, click *OK*.
 +
-image::images/i13-jboss-defined.png[title="WildFly defined in IntelliJ IDEA"]
+image::i13-jboss-defined.png[title="WildFly defined in IntelliJ IDEA"]
 
 [[create-project-wildfly-idea]]
 ==== Create a project
 
 The sample application is supplied as a Maven project with an associated http://maven.apache.org/pom.html[pom.xml] file that contains all the necessary project definitions. The corresponding IntelliJ IDEA project in such a case can be created by simply "opening" the +pom.xml+ file. (Obviously, this isn't the only way to create projects in IDEA. You can create projects for existing collections of source files, import Eclipse and Flash Builder projects, and Gradle build scripts. Finally, you can create projects from scratch.)
 
-. On the Welcome screen, to the left of *Configure*, click *Back* image::images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
+. On the Welcome screen, to the left of *Configure*, click *Back* image:images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
 +
 . Under *Quick Start*, click *Open Project*.
 +
-image::images/i13-open-project.png[title="Open project in IntelliJ IDEA"]
+image::i13-open-project.png[title="Open project in IntelliJ IDEA"]
 +
 . In the *Open Project* dialog, select the +pom.xml+ file associated with the sample application, and click *OK*.
 +
-image::images/i13-select-pom.png[title="Select pom in IntelliJ IDEA"]
+image::i13-select-pom.png[title="Select pom in IntelliJ IDEA"]
 +
 Wait while IntelliJ IDEA is processing +pom.xml+ and creating the project. When this process is complete, the following message is shown:
 +
-image::images/i13-jpa-detected.png[title="Configure JPA in IntelliJ IDEA"]
+image::i13-jpa-detected.png[title="Configure JPA in IntelliJ IDEA"]
 +
-. Click *Configure* in the message box. (If by now the message has disappeared, click image::images/i13-exclamation-mark-icon.png[title="Mark icon in IntelliJ IDEA"] on the Status bar.
+. Click *Configure* in the message box. (If by now the message has disappeared, click image:images/i13-exclamation-mark-icon.png[title="Mark icon in IntelliJ IDEA"] on the Status bar.
 +
-image::images/i13-jpa-detected-status-bar.png[title="JPA detected in status bar in IntelliJ IDEA"]
+image::i13-jpa-detected-status-bar.png[title="JPA detected in status bar in IntelliJ IDEA"]
 +
 The *Event Log* tool window will open. Click *Configure* in this window.)
 +
-image::images/i13-jpa-detected-event-log.png[title="JPA detected event log in IntelliJ IDEA"]
+image::i13-jpa-detected-event-log.png[title="JPA detected event log in IntelliJ IDEA"]
 +
 . In the *Setup Frameworks* dialog, just click *OK*. (By doing so you confirm that the file +persistence.xml+ found in the project belongs to the JPA framework.)
 +
-image::images/i13-setup-frameworks-jpa.png[title="Setup frameworks in IntelliJ IDEA"]
+image::i13-setup-frameworks-jpa.png[title="Setup frameworks in IntelliJ IDEA"]
 +
 Now, as an intermediate check, make sure that the project structure looks something similar to this:
 +
-image::images/i13-initial-project-structure.png[title="Project structure in IntelliJ IDEA"]
+image::i13-initial-project-structure.png[title="Project structure in IntelliJ IDEA"]
 
 [[create-run-config-wildfly-idea]]
 ==== Create a run/debug configuration
@@ -171,11 +173,11 @@ Applications in IntelliJ IDEA are run and debugged according to what is called r
 
 . In the main menu, select *Run | Edit Configurations*.
 +
-image::images/i13-run-edit-configurations.png[title="Edit configurations in IntelliJ IDEA"]
+image::i13-run-edit-configurations.png[title="Edit configurations in IntelliJ IDEA"]
 +
-. In the *Run/Debug Configurations* dialog, click image::images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"], select *JBoss Server*, and then select *Local*.
+. In the *Run/Debug Configurations* dialog, click image:images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"], select *JBoss Server*, and then select *Local*.
 +
-image::images/i13-run-configs-plus-jboss.png[title="WildFly configuration in IntelliJ IDEA"]
+image::i13-run-configs-plus-jboss.png[title="WildFly configuration in IntelliJ IDEA"]
 +
 As a result, the run/debug configuration for the WildFly server is created and its settings are shown in the right-hand part of the dialog.
 +
@@ -183,36 +185,36 @@ As a result, the run/debug configuration for the WildFly server is created and i
 +
 . In the lower part of the dialog, within the line _Warning: No artifacts marked for deployment_, click *Fix* and select *movieplex7:war exploded*. (Artifacts in IntelliJ IDEA are deployment-ready project outputs and also the configurations according to which such outputs are produced. In our case, there are two configurations for the sample application (_movieplex7:war_ and _movieplex7:war exploded_). Both configurations represent a format suitable for deployment onto a Java EE 7-enabled application server. _movieplex7:war_ corresponds to a Web archive (WAR). _movieplex7:war exploded_ corresponds to the sample application directory structure (a decompressed archive). The second of the formats is more suitable at the development stage because manipulations with it are faster.)
 +
-image::images/i13-jboss-fix-deployment.png[title="Fixing deployment warning in IntelliJ IDEA"]
+image::i13-jboss-fix-deployment.png[title="Fixing deployment warning in IntelliJ IDEA"]
 +
 . Within the line _Error: Artifact $$'movieplex7: exploded'$$ has invalid extension_, click *Fix*.
 +
-image::images/i13-jboss-invalid-extension.png[title="Invalid extension error message in IntelliJ IDEA"]
+image::i13-jboss-invalid-extension.png[title="Invalid extension error message in IntelliJ IDEA"]
 +
 . In the *Project Structure* dialog, add +.war+ at the end of the output directory path, and click *OK*. (For the servers of the JBoss family, the application root directory has to have +.war+ at the end.)
 +
-image::images/i13-jboss-fix-extension.png[title="Extension error fix in IntelliJ IDEA"]
+image::i13-jboss-fix-extension.png[title="Extension error fix in IntelliJ IDEA"]
 +
 . In the *Run/Debug Configurations* dialog, switch to the *Server* tab. In the field for the application starting page URL, replace +$$http://localhost:8080/movieplex7-1/$$+ with +$$http://localhost:8080/movieplex7-1.0-SNAPSHOT/$$+ and click *OK*.
 +
-image::images/i13-jboss-url-fixed.png[title="Fixing application URL in IntelliJ IDEA"]
+image::i13-jboss-url-fixed.png[title="Fixing application URL in IntelliJ IDEA"]
 
 The *Application Servers* tool window opens in the lower part of the workspace. Shown in this window are the server run/debug configuration and the associated deployment artifact. Now you are ready to run the application.
 
 [[run-app-wildfly-idea]]
 ==== Run the application
 
-In the *Application Servers* tool window, select the server run/debug configuration (_WildFly8 [local]_) and click *Run* image::images/i13-run-icon.png[title="Run icon in IntelliJ IDEA"].
+In the *Application Servers* tool window, select the server run/debug configuration (_WildFly8 [local]_) and click *Run* image:images/i13-run-icon.png[title="Run icon in IntelliJ IDEA"].
 
-image::images/i13-run-wildfly.png[title="Run WildFly in IntelliJ IDEA"]
+image::i13-run-wildfly.png[title="Run WildFly in IntelliJ IDEA"]
 
 IntelliJ IDEA compiles the code, builds the artifact, starts WildFly and deploys the artifact to the server. You can monitor this process in the *Run* tool window that opens in the lower part of the workspace.
 
-image::images/i13-run-tool-window-wildfly.png[title="Run tool window in IntelliJ IDEA"]
+image::i13-run-tool-window-wildfly.png[title="Run tool window in IntelliJ IDEA"]
 
 Finally, your default Web browser opens and the starting page of the application is shown.
 
-image::images/i13-starting-page-in-browser.png[title="Starting page in browser from IntelliJ IDEA"]
+image::i13-starting-page-in-browser.png[title="Starting page in browser from IntelliJ IDEA"]
 
 At this step IntelliJ IDEA is fully prepared for your development work, and you can continue with your exercises.
 
@@ -226,7 +228,7 @@ ifdef::server-glassfish[]
 +
 . Right-click on Servers, choose `Add Server...' in the pop-up menu.
 +
-image::images/netbeans-addserver.png[title="Add Server in NetBeans"]
+image::netbeans-addserver.png[title="Add Server in NetBeans"]
 +
 . Select `GlassFish Server' in the Add Server Instance wizard, set the
 name to `GlassFish 4.0' and click `Next >'.
@@ -261,27 +263,27 @@ First of all, you should specify the JDK that you are going to use. In IntelliJ 
 +
 . On the Welcome screen, under *Quick Start*, click *Configure*.
 +
-image::images/i13-welcome-configure.png[image]
+image::i13-welcome-configure.png[image]
 +
 . Under *Configure*, click *Project Defaults*, and then, under *Project Defaults*, click *Project Structure*.
 +
-. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image::images/i13-plus-icon.png[image] and select *JDK*.
+. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image:images/i13-plus-icon.png[image] and select *JDK*.
 +
-image::images/i13-plus-jdk.png[image]
+image::i13-plus-jdk.png[image]
 +
 . In the *Select Home Directory for JDK* dialog, select the folder in which the JDK that you are going to use is installed, and click *OK*.
 +
-image::images/i13-jdk-home.png[image]
+image::i13-jdk-home.png[image]
 +
 . In the *Project Structure* dialog, click *Apply*.
 +
-image::images/i13-jdk-defined.png[image]
+image::i13-jdk-defined.png[image]
 +
 Now, let's make the JDK that we have specified the default SDK.
 +
 . In the left-hand pane, under *Project Settings*, select *Project*. In the right-hand part of the dialog, under *Project SDK*, select the JDK from the list.
 +
-image::images/i13-project-sdk.png[image]
+image::i13-project-sdk.png[image]
 +
 . Click *OK*.
 
@@ -290,64 +292,64 @@ image::images/i13-project-sdk.png[image]
 
 Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On Mac OS, this dialog is called *Preferences*.)
 
-. On the Welcome screen, to the left of *Project Defaults*, click *Back* image::images/i13-back-icon.png[image].
+. On the Welcome screen, to the left of *Project Defaults*, click *Back* image:images/i13-back-icon.png[image].
 +
 . Under *Configure*, click *Settings*.
 +
-. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image::images/i13-plus-icon.png[image] and select *GlassFish Server*.
+. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image:images/i13-plus-icon.png[image] and select *GlassFish Server*.
 +
-image::images/i13-plus-glassfish.png[image]
+image::i13-plus-glassfish.png[image]
 +
-. In the *GlassFish Server* dialog, click image::images/i13-ellipsis-button.png[image] to the right of the *GlassFish Home* field.
+. In the *GlassFish Server* dialog, click image:images/i13-ellipsis-button.png[image] to the right of the *GlassFish Home* field.
 +
-image::images/i13-glassfish-server-dialog-initial.png[image]
+image::i13-glassfish-server-dialog-initial.png[image]
 +
 . In the *GlassFish Home Directory* dialog, select the folder in which you have the GlassFish server installed, and click *OK*.
 +
-image::images/i13-glassfish-home-directory.png[image]
+image::i13-glassfish-home-directory.png[image]
 +
 . Click *OK* in the *GlassFish Server* dialog.
 +
-image::images/i13-glassfish-server-dialog-final.png[image]
+image::i13-glassfish-server-dialog-final.png[image]
 +
 . In the *Settings* (*Preferences*) dialog, click *OK*.
 +
-image::images/i13-glassfish-defined.png[image]
+image::i13-glassfish-defined.png[image]
 
 [[create-project-glassfish-idea]]
 ==== Create a project
 
 The sample application is supplied as a Maven project with an associated http://maven.apache.org/pom.html[pom.xml] file that contains all the necessary project definitions. The corresponding IntelliJ IDEA project in such a case can be created by simply "opening" the +pom.xml+ file. (Obviously, this isn't the only way to create projects in IDEA. You can create projects for existing collections of source files, import Eclipse and Flash Builder projects, and Gradle build scripts. Finally, you can create projects from scratch.)
 
-. On the Welcome screen, to the left of *Configure*, click *Back* image::images/i13-back-icon.png[image].
+. On the Welcome screen, to the left of *Configure*, click *Back* image:images/i13-back-icon.png[image].
 +
 . Under *Quick Start*, click *Open Project*.
 +
-image::images/i13-open-project.png[image]
+image::i13-open-project.png[image]
 +
 . In the *Open Project* dialog, select the +pom.xml+ file associated with the sample application, and click *OK*.
 +
-image::images/i13-select-pom.png[image]
+image::i13-select-pom.png[image]
 +
 Wait while IntelliJ IDEA is processing +pom.xml+ and creating the project. When this process is complete, the following message is shown:
 +
-image::images/i13-jpa-detected.png[image]
+image::i13-jpa-detected.png[image]
 +
-. Click *Configure* in the message box. (If by now the message has disappeared, click image::images/i13-exclamation-mark-icon.png[image] on the Status bar.
+. Click *Configure* in the message box. (If by now the message has disappeared, click image:images/i13-exclamation-mark-icon.png[image] on the Status bar.
 +
-image::images/i13-jpa-detected-status-bar.png[image]
+image::i13-jpa-detected-status-bar.png[image]
 +
 The *Event Log* tool window will open. Click *Configure* in this window.)
 +
-image::images/i13-jpa-detected-event-log.png[image]
+image::i13-jpa-detected-event-log.png[image]
 +
 . In the *Setup Frameworks* dialog, just click *OK*. (By doing so you confirm that the file +persistence.xml+ found in the project belongs to the JPA framework.)
 +
-image::images/i13-setup-frameworks-jpa.png[image]
+image::i13-setup-frameworks-jpa.png[image]
 +
 Now, as an intermediate check, make sure that the project structure looks something similar to this:
 +
-image::images/i13-initial-project-structure.png[image]
+image::i13-initial-project-structure.png[image]
 
 [[create-run-config-glassfish-idea]]
 ==== Create a run/debug configuration
@@ -356,11 +358,11 @@ Applications in IntelliJ IDEA are run and debugged according to what is called r
 
 . In the main menu, select *Run | Edit Configurations*.
 +
-image::images/i13-run-edit-configurations.png[image]
+image::i13-run-edit-configurations.png[image]
 +
-. In the *Run/Debug Configurations* dialog, click image::images/i13-plus-icon.png[image], select *GlassFish Server*, and then select *Local*.
+. In the *Run/Debug Configurations* dialog, click image:images/i13-plus-icon.png[image], select *GlassFish Server*, and then select *Local*.
 +
-image::images/i13-run-configs-plus-glassfish.png[image]
+image::i13-run-configs-plus-glassfish.png[image]
 +
 As a result, the run/debug configuration for the GlassFish server is created and its settings are shown in the right-hand part of the dialog.
 +
@@ -368,15 +370,15 @@ As a result, the run/debug configuration for the GlassFish server is created and
 +
 . Note the error message in the lower part of the dialog: _Error: Domain not specified_. To fix this, select *domain1* from the *Server Domain* list.
 +
-image::images/i13-glassfish-fix-domain.png[image]
+image::i13-glassfish-fix-domain.png[image]
 +
 . In the lower part of the dialog, within the line _Warning: No artifacts marked for deployment_, click *Fix* and select *movieplex7:war exploded*. (Artifacts in IntelliJ IDEA are deployment-ready project outputs and also the configurations according to which such outputs are produced. In our case, there are two configurations for the sample application (_movieplex7:war_ and _movieplex7:war exploded_). Both configurations represent a format suitable for deployment onto a Java EE 7-enabled application server. _movieplex7:war_ corresponds to a Web archive (WAR). _movieplex7:war exploded_ corresponds to the sample application directory structure (a decompressed archive). The second of the formats is more suitable at the development stage because manipulations with it are faster.)
 +
-image::images/i13-glassfish-fix-deployment.png[image]
+image::i13-glassfish-fix-deployment.png[image]
 +
 . Switch to the *Server* tab. In the field for the application starting page URL, replace +$$http://localhost:8080/movieplex7-1/$$+ with +$$http://localhost:8080/movieplex7-1.0-SNAPSHOT/$$+ and click *OK*.
 +
-image::images/i13-glassfish-fix-url.png[image]
+image::i13-glassfish-fix-url.png[image]
 
 The *Application Servers* tool window opens in the lower part of the workspace. Shown in this window are the server run/debug configuration and the associated deployment artifact. Now you are ready to run the application.
 
@@ -389,27 +391,27 @@ Before executing the run/debug configuration you have to make sure that the Glas
 
 You can start the database right from IntelliJ IDEA by running the +asadmin start-database+ command in the *Terminal* tool window. (The +asadmin+ utility is located in the +$$<$$GlassFish_installation_folder$$>$$\bin+ directory.)
 
-. Open the *Terminal* tool window. You can do that, for example, like this: point to image::images/i13-show-tool-windows-icon.png[image] on the Status bar and select *Terminal*.
+. Open the *Terminal* tool window. You can do that, for example, like this: point to image:images/i13-show-tool-windows-icon.png[image] on the Status bar and select *Terminal*.
 +
-image::images/i13-open-terminal.png[image]
+image::i13-open-terminal.png[image]
 +
 . Run the +asadmin start-database+ command.
 +
-image::images/i13-glassfish-start-database.png[image]
+image::i13-glassfish-start-database.png[image]
 +
 As a result, the database will start, or you will be told that the database is already running.
 +
 . Execute the run/debug configuration. You can do that, for example, by selecting *Run | Run $$'$$GlassFish4$$'$$* from the main menu.
 +
-image::images/i13-run-glassfish.png[image]
+image::i13-run-glassfish.png[image]
 +
 IntelliJ IDEA compiles the code, builds the artifact, starts FlassFish and deploys the artifact to the server. You can monitor this process in the *Run* tool window that opens in the lower part of the workspace.
 +
-image::images/i13-run-tool-window-glassfish.png[image]
+image::i13-run-tool-window-glassfish.png[image]
 +
 Finally, your default Web browser opens and the starting page of the application is shown.
 +
-image::images/i13-starting-page-in-browser.png[image]
+image::i13-starting-page-in-browser.png[image]
 
 At this step IntelliJ IDEA is fully prepared for your development work, and you can continue with your exercises.
 
@@ -424,37 +426,37 @@ At this step IntelliJ IDEA is fully prepared for your development work, and you 
 +
 . Open the project in IntelliJ IDEA. If your IDEA version is new it will need to use the new project format. In that case IDEA will ask you to convert the project. Just confirm that with `Convert'.
 +
-image::images/idea-convertproject.png[Convert Project]
+image::idea-convertproject.png[Convert Project]
 +
 . Once the project was opened IDEA will detect the JPA framework usage and offer you to configure it. Click on `Configure'.
 +
-image::images/idea-configure-jpa.png[Configure Frameworks]
+image::idea-configure-jpa.png[Configure Frameworks]
 +
 . In the dialog box that shows up make sure the only detected file in there says `persistence.xml` and is checked and confirm  it with `Ok'.
 +
-image::images/idea-configure-jpa-dialogbox.png[Setup Frameworks]
+image::idea-configure-jpa-dialogbox.png[Setup Frameworks]
 +
 . As a next step we need to build the project. Open the ”Maven Projects” pane on the right-hand side of your IDEA window and click on the two arrows (top left-hand side) pointing at each other. The Maven project will be detected and it will ask you if the project may be reopened now due to a language level change. Confirm with `Yes'.
 +
-image::images/idea-open-mavenprojects-pane.png[Find Maven Project]
+image::idea-open-mavenprojects-pane.png[Find Maven Project]
 +
 . When the project is reloaded go to the `Maven Projects' pane again and have Maven build and package the project by selecting `Java EE 7 Hands-on Lab > Lifecycle > package' and clicking on the green `play' arrow. When you do that you might have to configure your Maven installation - in that case just choose the Maven home directory in the configuration dialog that is offered. Afterwards also click on `Enable Auto-Import' if a green hint pops up.
 +
-image::images/idea-mavenprojects-run-package-command.png[Run `maven package` Command]
+image::idea-mavenprojects-run-package-command.png[Run `maven package` Command]
 +
 . In the menu click on `Run > Edit Configurations'.
 +
 . In the dialog box that comes up click on the Plus-sign in the top-left corner and at the bottom select the entry `(17 more items)`. Your mileage may vary here, depending on your IntelliJ IDEA setup. A configuration option for `GlassFish Server' should show up.
 +
-image::images/idea-add-glassfish-server-configuration.png[Add GlassFish Server Configuration]
+image::idea-add-glassfish-server-configuration.png[Add GlassFish Server Configuration]
 +
 . Pick `Local' and in the upcoming dialog box enter a name (e.g. `GlassFish Server 4.0.0` - depending on your GlassFish Server version) and uncheck `After launch' so the browser doesn't get opened after each redeploy. In the textfield for ”Server Domain” enter `domain1` as the name of the domain. Leave the `Username' field at `admin` and the `Password` field empty. Then click `Configure' next to the `Application server' drop down list, in the upcoming dialog box click on the Plus-sign in the top-left corner and enter the root path of your GlassFish Server installation. If you also have NetBeans 7.4 on your computer then it will show up under the NetBeans folder. Confirm this dialog box to have it closed.
 +
-image::images/idea-edit-glassfish-server-configuration-servertab.png[Configure GlassFish Server]
+image::idea-edit-glassfish-server-configuration-servertab.png[Configure GlassFish Server]
 +
 . Now click on the `Deployment' tab, then click on the Plus-sign underneath the large empty white area labeled `Deploy at the server startup' and choose `Artifact`. Choose the entry `movieplex7:war` and click `Ok'. Click `Ok' again to close the entire configuration dialog. We're now done.
 +
-image::images/idea-edit-glassfish-server-configuration-deploymenttab.png[Configure Deployment]
+image::idea-edit-glassfish-server-configuration-deploymenttab.png[Configure Deployment]
 +
 . As a final step we need to start the database. For NetBeans users this happens automagically but we'll have to do that manually when using IDEA. Just go to your GlassFish Server installation folder's `bin/`-directory and enter the following command `asadmin start-database`, or for Mac/Linux users: `./asadmin start-database` and you're good to go.
 

--- a/docs/chapters/appendix.adoc
+++ b/docs/chapters/appendix.adoc
@@ -1,4 +1,10 @@
 :imagesdir: ../images
+:experimental:
+ifndef::server-glassfish[]
+ifndef::server-wildfly[]
+:server-wildfly:
+endif::server-wildfly[]
+endif::server-glassfish[]
 
 [appendix]
 == Appendix
@@ -15,7 +21,7 @@ ifdef::server-wildfly[]
 +
 image::16-netbeans-add-dev-update-center.png[title="NetBeans Update Center"]
 +
-and click on `OK'.
+and click on btn:[OK].
 
 [[install-wildfly-plugin]]
 ==== Install WildFly plugin
@@ -25,7 +31,7 @@ and click on `OK'.
 image::16-netbeans-available-plugins-wildfly.png[title="Available Plugins in NetBeans"]
 +
 The exact plugin version and the date may be different.
-. Click on `Install' button, `Next >', accept the license agreement by clicking on the checkbox, and click on `Install' button to install the plugin. Click on `Finish' to restart the IDE and complete installation.
+. Click the btn:[Install] button, then btn:[Next >], accept the license agreement by clicking on the checkbox, then click the btn:[Install] button to install the plugin. Click the btn:[Finish] button to restart the IDE and complete installation.
 
 ==== Configure WildFly 8
 
@@ -36,18 +42,18 @@ The exact plugin version and the date may be different.
 image::netbeans-addserver.png[title="Add Server in NetBeans"]
 +
 . Select `WildFly Application Server' in the Add Server Instance wizard, set the
-name to `WildFly 8' and click `Next >'.
+name to `WildFly 8' and click btn:[Next >].
 +
 image::16-netbeans-add-instance-wildfly.png[title="Add WildFly instance to NetBeans"]
 +
-. Click on `Browse' for `Server Location' and select the directory that got created
-when WildFly archive was unzipped. Click on `Browse' for `Server Configuration' and
+. Click on btn:[Browse...] for `Server Location' and select the directory that got created
+when WildFly archive was unzipped. Click on btn:[Browse...] for `Server Configuration' and
 select the `standalone/configuration/standalone-full.xml' file in the unzipped WildFly
 archive.
 +
 image::16-netbeans-wildfly-full-platform.png[title="Configure WildFly full instance in NetBeans"]
 +
-Click on `Next' and then `Finish'. The `Services' should show the WildFly instance.
+Click on btn:[Next] and then btn:[Finish]. The `Services' should show the WildFly instance.
 +
 image::16-netbeans-wildfly-server.png[title="WildFly instance in NetBeans Services tab"]
 
@@ -74,7 +80,7 @@ When the appropriate edition of IntelliJ IDEA is installed, you can start prepar
 
 First of all, you should specify the JDK that you are going to use. In IntelliJ IDEA, this is done in the *Project Structure* dialog:
 
-. Start IntelliJ IDEA. If, as a result, a project opens, close the project (*File | Close Project*).
+. Start IntelliJ IDEA. If, as a result, a project opens, close the project (menu:File[Close Project]).
 +
 . On the Welcome screen, under *Quick Start*, click *Configure*.
 +
@@ -82,15 +88,15 @@ image::i13-welcome-configure.png[title="Welcome to IntelliJ IDEA"]
 +
 . Under *Configure*, click *Project Defaults*, and then, under *Project Defaults*, click *Project Structure*.
 +
-. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image:images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JDK*.
+. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image:i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JDK*.
 +
 image::i13-plus-jdk.png[title="Add JDK in IntelliJ IDEA"]
 +
-. In the *Select Home Directory for JDK* dialog, select the folder in which the JDK that you are going to use is installed, and click *OK*.
+. In the *Select Home Directory for JDK* dialog, select the folder in which the JDK that you are going to use is installed, and click btn:[OK].
 +
 image::i13-jdk-home.png[title="JDK home in IntelliJ IDEA"]
 +
-. In the *Project Structure* dialog, click *Apply*.
+. In the *Project Structure* dialog, click btn:[Apply].
 +
 image::i13-jdk-defined.png[title="JDK defined in IntelliJ IDEA"]
 +
@@ -100,26 +106,26 @@ Now, let's make the JDK that we have specified the default SDK.
 +
 image::i13-project-sdk.png[title="Project SDK in IntelliJ IDEA"]
 +
-. Click *OK*.
+. Click btn:[OK].
 
 [[define-wildfly-idea]]
 ==== Define WildFly
 
 Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On OSX, this dialog is called *Preferences*.)
 
-. On the Welcome screen, to the left of *Project Defaults*, click *Back* image:images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
+. On the Welcome screen, to the left of *Project Defaults*, click *Back* image:i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
 +
 . Under *Configure*, click *Settings*.
 +
-. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image:images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JBoss Server*. (WildFly is a server from the "JBoss family".)
+. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image:i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"] and select *JBoss Server*. (WildFly is a server from the "JBoss family".)
 +
 image::i13-plus-jboss.png[title="Add WildFly in IntelliJ IDEA"]
 +
-. In the *JBoss Server* dialog, click image:images/i13-ellipsis-button.png[title="Ellipsis button in IntelliJ IDEA"] to the right of the *JBoss Home* field.
+. In the *JBoss Server* dialog, click image:i13-ellipsis-button.png[title="Ellipsis button in IntelliJ IDEA"] to the right of the *JBoss Home* field.
 +
 image::i13-jboss-server-dialog-initial.png[title="WildFly server dialog in IntelliJ IDEA"]
 +
-. In the *JBoss Home Directory* dialog, select the folder in which you have the WildFly server installed, and click *OK*.
+. In the *JBoss Home Directory* dialog, select the folder in which you have the WildFly server installed, and click btn:[OK].
 +
 image::i13-jboss-home-directory.png[title="WildFly home in IntelliJ IDEA"]
 +
@@ -127,7 +133,7 @@ image::i13-jboss-home-directory.png[title="WildFly home in IntelliJ IDEA"]
 +
 image::i13-jboss-server-dialog-final.png[title="WildFly final dialog in IntelliJ IDEA"]
 +
-. In the *Settings* (*Preferences*) dialog, click *OK*.
+. In the *Settings* (*Preferences*) dialog, click btn:[OK].
 +
 image::i13-jboss-defined.png[title="WildFly defined in IntelliJ IDEA"]
 
@@ -136,13 +142,13 @@ image::i13-jboss-defined.png[title="WildFly defined in IntelliJ IDEA"]
 
 The sample application is supplied as a Maven project with an associated http://maven.apache.org/pom.html[pom.xml] file that contains all the necessary project definitions. The corresponding IntelliJ IDEA project in such a case can be created by simply "opening" the +pom.xml+ file. (Obviously, this isn't the only way to create projects in IDEA. You can create projects for existing collections of source files, import Eclipse and Flash Builder projects, and Gradle build scripts. Finally, you can create projects from scratch.)
 
-. On the Welcome screen, to the left of *Configure*, click *Back* image:images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
+. On the Welcome screen, to the left of *Configure*, click *Back* image:i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
 +
 . Under *Quick Start*, click *Open Project*.
 +
 image::i13-open-project.png[title="Open project in IntelliJ IDEA"]
 +
-. In the *Open Project* dialog, select the +pom.xml+ file associated with the sample application, and click *OK*.
+. In the *Open Project* dialog, select the +pom.xml+ file associated with the sample application, and click btn:[OK].
 +
 image::i13-select-pom.png[title="Select pom in IntelliJ IDEA"]
 +
@@ -150,7 +156,7 @@ Wait while IntelliJ IDEA is processing +pom.xml+ and creating the project. When 
 +
 image::i13-jpa-detected.png[title="Configure JPA in IntelliJ IDEA"]
 +
-. Click *Configure* in the message box. (If by now the message has disappeared, click image:images/i13-exclamation-mark-icon.png[title="Mark icon in IntelliJ IDEA"] on the Status bar.
+. Click *Configure* in the message box. (If by now the message has disappeared, click image:i13-exclamation-mark-icon.png[title="Mark icon in IntelliJ IDEA"] on the Status bar.
 +
 image::i13-jpa-detected-status-bar.png[title="JPA detected in status bar in IntelliJ IDEA"]
 +
@@ -158,7 +164,7 @@ The *Event Log* tool window will open. Click *Configure* in this window.)
 +
 image::i13-jpa-detected-event-log.png[title="JPA detected event log in IntelliJ IDEA"]
 +
-. In the *Setup Frameworks* dialog, just click *OK*. (By doing so you confirm that the file +persistence.xml+ found in the project belongs to the JPA framework.)
+. In the *Setup Frameworks* dialog, just click btn:[OK]. (By doing so you confirm that the file +persistence.xml+ found in the project belongs to the JPA framework.)
 +
 image::i13-setup-frameworks-jpa.png[title="Setup frameworks in IntelliJ IDEA"]
 +
@@ -171,11 +177,11 @@ image::i13-initial-project-structure.png[title="Project structure in IntelliJ ID
 
 Applications in IntelliJ IDEA are run and debugged according to what is called run/debug configurations. Now we are going to create the configuration for running and debugging the sample application in the context of WildFly.
 
-. In the main menu, select *Run | Edit Configurations*.
+. In the main menu, select menu:Run[Edit Configurations...].
 +
 image::i13-run-edit-configurations.png[title="Edit configurations in IntelliJ IDEA"]
 +
-. In the *Run/Debug Configurations* dialog, click image:images/i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"], select *JBoss Server*, and then select *Local*.
+. In the *Run/Debug Configurations* dialog, click image:i13-plus-icon.png[title="Plus icon in IntelliJ IDEA"], select *JBoss Server*, and then select *Local*.
 +
 image::i13-run-configs-plus-jboss.png[title="WildFly configuration in IntelliJ IDEA"]
 +
@@ -183,19 +189,19 @@ As a result, the run/debug configuration for the WildFly server is created and i
 +
 . Change the name of the run/debug configuration to +WildFly8+ (optional).
 +
-. In the lower part of the dialog, within the line _Warning: No artifacts marked for deployment_, click *Fix* and select *movieplex7:war exploded*. (Artifacts in IntelliJ IDEA are deployment-ready project outputs and also the configurations according to which such outputs are produced. In our case, there are two configurations for the sample application (_movieplex7:war_ and _movieplex7:war exploded_). Both configurations represent a format suitable for deployment onto a Java EE 7-enabled application server. _movieplex7:war_ corresponds to a Web archive (WAR). _movieplex7:war exploded_ corresponds to the sample application directory structure (a decompressed archive). The second of the formats is more suitable at the development stage because manipulations with it are faster.)
+. In the lower part of the dialog, within the line _Warning: No artifacts marked for deployment_, click btn:[Fix] and select *movieplex7:war exploded*. (Artifacts in IntelliJ IDEA are deployment-ready project outputs and also the configurations according to which such outputs are produced. In our case, there are two configurations for the sample application (_movieplex7:war_ and _movieplex7:war exploded_). Both configurations represent a format suitable for deployment onto a Java EE 7-enabled application server. _movieplex7:war_ corresponds to a Web archive (WAR). _movieplex7:war exploded_ corresponds to the sample application directory structure (a decompressed archive). The second of the formats is more suitable at the development stage because manipulations with it are faster.)
 +
 image::i13-jboss-fix-deployment.png[title="Fixing deployment warning in IntelliJ IDEA"]
 +
-. Within the line _Error: Artifact $$'movieplex7: exploded'$$ has invalid extension_, click *Fix*.
+. Within the line _Error: Artifact $$'movieplex7: exploded'$$ has invalid extension_, click btn:[Fix].
 +
 image::i13-jboss-invalid-extension.png[title="Invalid extension error message in IntelliJ IDEA"]
 +
-. In the *Project Structure* dialog, add +.war+ at the end of the output directory path, and click *OK*. (For the servers of the JBoss family, the application root directory has to have +.war+ at the end.)
+. In the *Project Structure* dialog, add +.war+ at the end of the output directory path, and click btn:[OK]. (For the servers of the JBoss family, the application root directory has to have +.war+ at the end.)
 +
 image::i13-jboss-fix-extension.png[title="Extension error fix in IntelliJ IDEA"]
 +
-. In the *Run/Debug Configurations* dialog, switch to the *Server* tab. In the field for the application starting page URL, replace +$$http://localhost:8080/movieplex7-1/$$+ with +$$http://localhost:8080/movieplex7-1.0-SNAPSHOT/$$+ and click *OK*.
+. In the *Run/Debug Configurations* dialog, switch to the *Server* tab. In the field for the application starting page URL, replace +$$http://localhost:8080/movieplex7-1/$$+ with +$$http://localhost:8080/movieplex7-1.0-SNAPSHOT/$$+ and click btn:[OK].
 +
 image::i13-jboss-url-fixed.png[title="Fixing application URL in IntelliJ IDEA"]
 
@@ -204,7 +210,7 @@ The *Application Servers* tool window opens in the lower part of the workspace. 
 [[run-app-wildfly-idea]]
 ==== Run the application
 
-In the *Application Servers* tool window, select the server run/debug configuration (_WildFly8 [local]_) and click *Run* image:images/i13-run-icon.png[title="Run icon in IntelliJ IDEA"].
+In the *Application Servers* tool window, select the server run/debug configuration (_WildFly8 [local]_) and click *Run* image:i13-run-icon.png[title="Run icon in IntelliJ IDEA"].
 
 image::i13-run-wildfly.png[title="Run WildFly in IntelliJ IDEA"]
 
@@ -219,7 +225,6 @@ image::i13-starting-page-in-browser.png[title="Starting page in browser from Int
 At this step IntelliJ IDEA is fully prepared for your development work, and you can continue with your exercises.
 
 endif::server-wildfly[]
-
 ifdef::server-glassfish[]
 [[appendix-glassfish4-netbeans]]
 === Configure GlassFish 4 in NetBeans
@@ -231,7 +236,7 @@ ifdef::server-glassfish[]
 image::netbeans-addserver.png[title="Add Server in NetBeans"]
 +
 . Select `GlassFish Server' in the Add Server Instance wizard, set the
-name to `GlassFish 4.0' and click `Next >'.
+name to `GlassFish 4.0' and click btn:[Next >].
 +
 . Click on `Browse …' and browse to where you unzipped the GlassFish
 build and point to the `glassfish4' directory that got created when you
@@ -259,7 +264,7 @@ When the appropriate edition of IntelliJ IDEA is installed, you can start prepar
 
 First of all, you should specify the JDK that you are going to use. In IntelliJ IDEA, this is done in the *Project Structure* dialog:
 
-. Start IntelliJ IDEA. If, as a result, a project opens, close the project (*File | Close Project*).
+. Start IntelliJ IDEA. If, as a result, a project opens, close the project (menu:File[Close Project]).
 +
 . On the Welcome screen, under *Quick Start*, click *Configure*.
 +
@@ -267,15 +272,15 @@ image::i13-welcome-configure.png[image]
 +
 . Under *Configure*, click *Project Defaults*, and then, under *Project Defaults*, click *Project Structure*.
 +
-. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image:images/i13-plus-icon.png[image] and select *JDK*.
+. In the left-hand pane of the *Project Structure* dialog, under *Platform Settings*, select *SDKs*. Click image:i13-plus-icon.png[image] and select *JDK*.
 +
 image::i13-plus-jdk.png[image]
 +
-. In the *Select Home Directory for JDK* dialog, select the folder in which the JDK that you are going to use is installed, and click *OK*.
+. In the *Select Home Directory for JDK* dialog, select the folder in which the JDK that you are going to use is installed, and click btn:[OK].
 +
 image::i13-jdk-home.png[image]
 +
-. In the *Project Structure* dialog, click *Apply*.
+. In the *Project Structure* dialog, click btn:[Apply].
 +
 image::i13-jdk-defined.png[image]
 +
@@ -292,19 +297,19 @@ image::i13-project-sdk.png[image]
 
 Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On OSX, this dialog is called *Preferences*.)
 
-. On the Welcome screen, to the left of *Project Defaults*, click *Back* image:images/i13-back-icon.png[image].
+. On the Welcome screen, to the left of *Project Defaults*, click *Back* image:i13-back-icon.png[image].
 +
 . Under *Configure*, click *Settings*.
 +
-. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image:images/i13-plus-icon.png[image] and select *GlassFish Server*.
+. In the left-hand pane of the *Settings* (*Preferences*) dialog, under *IDE Settings*, select *Application Servers*. On the *Application Servers* page, click image:i13-plus-icon.png[image] and select *GlassFish Server*.
 +
 image::i13-plus-glassfish.png[image]
 +
-. In the *GlassFish Server* dialog, click image:images/i13-ellipsis-button.png[image] to the right of the *GlassFish Home* field.
+. In the *GlassFish Server* dialog, click image:i13-ellipsis-button.png[image] to the right of the *GlassFish Home* field.
 +
 image::i13-glassfish-server-dialog-initial.png[image]
 +
-. In the *GlassFish Home Directory* dialog, select the folder in which you have the GlassFish server installed, and click *OK*.
+. In the *GlassFish Home Directory* dialog, select the folder in which you have the GlassFish server installed, and click btn:[OK].
 +
 image::i13-glassfish-home-directory.png[image]
 +
@@ -312,7 +317,7 @@ image::i13-glassfish-home-directory.png[image]
 +
 image::i13-glassfish-server-dialog-final.png[image]
 +
-. In the *Settings* (*Preferences*) dialog, click *OK*.
+. In the *Settings* (*Preferences*) dialog, click btn:[OK].
 +
 image::i13-glassfish-defined.png[image]
 
@@ -321,13 +326,13 @@ image::i13-glassfish-defined.png[image]
 
 The sample application is supplied as a Maven project with an associated http://maven.apache.org/pom.html[pom.xml] file that contains all the necessary project definitions. The corresponding IntelliJ IDEA project in such a case can be created by simply "opening" the +pom.xml+ file. (Obviously, this isn't the only way to create projects in IDEA. You can create projects for existing collections of source files, import Eclipse and Flash Builder projects, and Gradle build scripts. Finally, you can create projects from scratch.)
 
-. On the Welcome screen, to the left of *Configure*, click *Back* image:images/i13-back-icon.png[image].
+. On the Welcome screen, to the left of *Configure*, click *Back* image:i13-back-icon.png[image].
 +
 . Under *Quick Start*, click *Open Project*.
 +
 image::i13-open-project.png[image]
 +
-. In the *Open Project* dialog, select the +pom.xml+ file associated with the sample application, and click *OK*.
+. In the *Open Project* dialog, select the +pom.xml+ file associated with the sample application, and click btn:[OK].
 +
 image::i13-select-pom.png[image]
 +
@@ -335,7 +340,7 @@ Wait while IntelliJ IDEA is processing +pom.xml+ and creating the project. When 
 +
 image::i13-jpa-detected.png[image]
 +
-. Click *Configure* in the message box. (If by now the message has disappeared, click image:images/i13-exclamation-mark-icon.png[image] on the Status bar.
+. Click *Configure* in the message box. (If by now the message has disappeared, click image:i13-exclamation-mark-icon.png[image] on the Status bar.
 +
 image::i13-jpa-detected-status-bar.png[image]
 +
@@ -343,7 +348,7 @@ The *Event Log* tool window will open. Click *Configure* in this window.)
 +
 image::i13-jpa-detected-event-log.png[image]
 +
-. In the *Setup Frameworks* dialog, just click *OK*. (By doing so you confirm that the file +persistence.xml+ found in the project belongs to the JPA framework.)
+. In the *Setup Frameworks* dialog, just click btn:[OK]. (By doing so you confirm that the file +persistence.xml+ found in the project belongs to the JPA framework.)
 +
 image::i13-setup-frameworks-jpa.png[image]
 +
@@ -356,11 +361,11 @@ image::i13-initial-project-structure.png[image]
 
 Applications in IntelliJ IDEA are run and debugged according to what is called run/debug configurations. Now we are going to create the configuration for running and debugging the sample application in the context of GlassFish.
 
-. In the main menu, select *Run | Edit Configurations*.
+. In the main menu, select menu:Run[Edit Configurations...].
 +
 image::i13-run-edit-configurations.png[image]
 +
-. In the *Run/Debug Configurations* dialog, click image:images/i13-plus-icon.png[image], select *GlassFish Server*, and then select *Local*.
+. In the *Run/Debug Configurations* dialog, click image:i13-plus-icon.png[image], select *GlassFish Server*, and then select *Local*.
 +
 image::i13-run-configs-plus-glassfish.png[image]
 +
@@ -372,11 +377,11 @@ As a result, the run/debug configuration for the GlassFish server is created and
 +
 image::i13-glassfish-fix-domain.png[image]
 +
-. In the lower part of the dialog, within the line _Warning: No artifacts marked for deployment_, click *Fix* and select *movieplex7:war exploded*. (Artifacts in IntelliJ IDEA are deployment-ready project outputs and also the configurations according to which such outputs are produced. In our case, there are two configurations for the sample application (_movieplex7:war_ and _movieplex7:war exploded_). Both configurations represent a format suitable for deployment onto a Java EE 7-enabled application server. _movieplex7:war_ corresponds to a Web archive (WAR). _movieplex7:war exploded_ corresponds to the sample application directory structure (a decompressed archive). The second of the formats is more suitable at the development stage because manipulations with it are faster.)
+. In the lower part of the dialog, within the line _Warning: No artifacts marked for deployment_, click btn:[Fix] and select *movieplex7:war exploded*. (Artifacts in IntelliJ IDEA are deployment-ready project outputs and also the configurations according to which such outputs are produced. In our case, there are two configurations for the sample application (_movieplex7:war_ and _movieplex7:war exploded_). Both configurations represent a format suitable for deployment onto a Java EE 7-enabled application server. _movieplex7:war_ corresponds to a Web archive (WAR). _movieplex7:war exploded_ corresponds to the sample application directory structure (a decompressed archive). The second of the formats is more suitable at the development stage because manipulations with it are faster.)
 +
 image::i13-glassfish-fix-deployment.png[image]
 +
-. Switch to the *Server* tab. In the field for the application starting page URL, replace +$$http://localhost:8080/movieplex7-1/$$+ with +$$http://localhost:8080/movieplex7-1.0-SNAPSHOT/$$+ and click *OK*.
+. Switch to the *Server* tab. In the field for the application starting page URL, replace +$$http://localhost:8080/movieplex7-1/$$+ with +$$http://localhost:8080/movieplex7-1.0-SNAPSHOT/$$+ and click btn:[OK].
 +
 image::i13-glassfish-fix-url.png[image]
 
@@ -391,7 +396,7 @@ Before executing the run/debug configuration you have to make sure that the Glas
 
 You can start the database right from IntelliJ IDEA by running the +asadmin start-database+ command in the *Terminal* tool window. (The +asadmin+ utility is located in the +$$<$$GlassFish_installation_folder$$>$$\bin+ directory.)
 
-. Open the *Terminal* tool window. You can do that, for example, like this: point to image:images/i13-show-tool-windows-icon.png[image] on the Status bar and select *Terminal*.
+. Open the *Terminal* tool window. You can do that, for example, like this: point to image:i13-show-tool-windows-icon.png[image] on the Status bar and select *Terminal*.
 +
 image::i13-open-terminal.png[image]
 +
@@ -401,7 +406,7 @@ image::i13-glassfish-start-database.png[image]
 +
 As a result, the database will start, or you will be told that the database is already running.
 +
-. Execute the run/debug configuration. You can do that, for example, by selecting *Run | Run $$'$$GlassFish4$$'$$* from the main menu.
+. Execute the run/debug configuration. You can do that, for example, by selecting menu:Run[Run {apos}GlassFish4{apos}] from the main menu.
 +
 image::i13-run-glassfish.png[image]
 +
@@ -444,7 +449,7 @@ image::idea-open-mavenprojects-pane.png[Find Maven Project]
 +
 image::idea-mavenprojects-run-package-command.png[Run `maven package` Command]
 +
-. In the menu click on `Run > Edit Configurations'.
+. In the menu click on menu:Run[Edit Configurations..].
 +
 . In the dialog box that comes up click on the Plus-sign in the top-left corner and at the bottom select the entry `(17 more items)`. Your mileage may vary here, depending on your IntelliJ IDEA setup. A configuration option for `GlassFish Server' should show up.
 +
@@ -460,9 +465,7 @@ image::idea-edit-glassfish-server-configuration-deploymenttab.png[Configure Depl
 +
 . As a final step we need to start the database. For NetBeans users this happens automagically but we'll have to do that manually when using IDEA. Just go to your GlassFish Server installation folder's `bin/`-directory and enter the following command `asadmin start-database`, or for OSX/Linux users: `./asadmin start-database` and you're good to go.
 
-. In the menu now choose `Run > Run GlassFish Server 4.0.0' (or whatever you named your GlassFish Server configuration) and your GlassFish Server will start up and deploy the project.
+. In the menu now choose menu:Run[Run GlassFish Server 4.0.0] (or whatever you named your GlassFish Server configuration) and your GlassFish Server will start up and deploy the project.
 
 . Open `http://localhost:8080/movieplex7-1.0-SNAPSHOT/` in your browser to see the (mostly empty) starter template.
-
 endif::server-glassfish[]
-

--- a/docs/chapters/appendix.adoc
+++ b/docs/chapters/appendix.adoc
@@ -105,7 +105,7 @@ image::i13-project-sdk.png[title="Project SDK in IntelliJ IDEA"]
 [[define-wildfly-idea]]
 ==== Define WildFly
 
-Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On Mac OS, this dialog is called *Preferences*.)
+Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On OSX, this dialog is called *Preferences*.)
 
 . On the Welcome screen, to the left of *Project Defaults*, click *Back* image:images/i13-back-icon.png[title="Back icon in IntelliJ IDEA"].
 +
@@ -290,7 +290,7 @@ image::i13-project-sdk.png[image]
 [[define-glassfish-idea]]
 ==== Define GlassFish
 
-Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On Mac OS, this dialog is called *Preferences*.)
+Defining an application server in IntelliJ IDEA, normally, is just telling the IDE where the server is installed. The servers are defined in the *Settings* dialog. (On OSX, this dialog is called *Preferences*.)
 
 . On the Welcome screen, to the left of *Project Defaults*, click *Back* image:images/i13-back-icon.png[image].
 +
@@ -458,7 +458,7 @@ image::idea-edit-glassfish-server-configuration-servertab.png[Configure GlassFis
 +
 image::idea-edit-glassfish-server-configuration-deploymenttab.png[Configure Deployment]
 +
-. As a final step we need to start the database. For NetBeans users this happens automagically but we'll have to do that manually when using IDEA. Just go to your GlassFish Server installation folder's `bin/`-directory and enter the following command `asadmin start-database`, or for Mac/Linux users: `./asadmin start-database` and you're good to go.
+. As a final step we need to start the database. For NetBeans users this happens automagically but we'll have to do that manually when using IDEA. Just go to your GlassFish Server installation folder's `bin/`-directory and enter the following command `asadmin start-database`, or for OSX/Linux users: `./asadmin start-database` and you're good to go.
 
 . In the menu now choose `Run > Run GlassFish Server 4.0.0' (or whatever you named your GlassFish Server configuration) and your GlassFish Server will start up and deploy the project.
 

--- a/docs/chapters/batch.adoc
+++ b/docs/chapters/batch.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[batch]]
 == Ticket Sales (Batch Applications for the Java Platform)
 
@@ -13,7 +15,7 @@ Applications for the Java Platform (JSR 352) will define a programming
 model for batch applications and a runtime for scheduling and executing
 jobs.
 
-image::images/5.0-batch-intro.png[title="Introduction to Batch"]
+image::5.0-batch-intro.png[title="Introduction to Batch"]
 
 The core concepts of Batch Processing are:
 
@@ -303,7 +305,7 @@ the bean to be injectable in an EL expression.
 +
 Resolve the imports.
 +
-image::images/5.10-imports.png[title="RequestScoped import"]
+image::5.10-imports.png[title="RequestScoped import"]
 +
 . Inject `EntityManagerFactory` in the class as:
 +
@@ -392,13 +394,13 @@ needs to be repeated for `f:` prefix.
 +
 . Run the project to see the output as shown.
 +
-image::images/5.14-sales.png[title="Sales link on main page"]
+image::5.14-sales.png[title="Sales link on main page"]
 +
 Notice, a new `Sales' entry is displayed in the left navigation bar.
 +
 . Click on `Sales' to see the output as shown.
 +
-image::images/5.15-sales.png[title="Movie Sales page"]
+image::5.15-sales.png[title="Movie Sales page"]
 +
 The empty table indicates that there is no sales data in the database.
 +
@@ -407,7 +409,7 @@ file. Look for `Waiting for localhost' in the browser status bar,
 wait for a couple of seconds for the processing to finish, and then
 click on `Refresh' button to see the updated output as shown.
 +
-image::images/5.16-sales-output.png[title="Movie Sales output page"]
+image::5.16-sales-output.png[title="Movie Sales output page"]
 +
 Now the table is populated with the sales data.
 +

--- a/docs/chapters/conclusion.adoc
+++ b/docs/chapters/conclusion.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Conclusion
 
 This hands-on lab built a trivial 3-tier web application using Java EE 7

--- a/docs/chapters/introduction.adoc
+++ b/docs/chapters/introduction.adoc
@@ -35,14 +35,10 @@ The following software needs to be downloaded and installed:
 
 * JDK 7 from
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[http://www.oracle.com/technetwork/java/javase/downloads/index.html].
-* *Application Server*: This lab can use WildFly 8 or GlassFish 4 as the application server. This document provide instructions for
-ifdef::server-wildfly[]
-WildFly 8.
-endif::server-wildfly[]
-ifdef::server-glassfish[]
-GlassFish.
-endif::server-glassfish[]
-* *IDE*: NetBeans 7.4+, JBoss Developer Studio (Eclipse-based), or IntelliJ IDEA 13 can be used. This document provide instructions for
+* *Application Server*: This lab can use WildFly 8 or GlassFish 4 as the application server. This document provides instructions for
+ifdef::server-wildfly[WildFly 8.]
+ifdef::server-glassfish[GlassFish.]
+* *IDE*: NetBeans 7.4+, JBoss Developer Studio (Eclipse-based), or IntelliJ IDEA 13 can be used. This document provides instructions for
 ifdef::ide-netbeans[]
 NetBeans 8.
 +
@@ -51,7 +47,8 @@ http://netbeans.org/downloads/[http://netbeans.org/downloads/]. A
 snapshot of the downloads page is shown and highlights the exact
 `Download' button to be clicked.
 +
-image::1.1-netbeans-download.png[title="NetBeans download"]
+.NetBeans download
+image::1.1-netbeans-download.png[]
 endif::ide-netbeans[]
 +
 ifdef::server-glassfish[]

--- a/docs/chapters/introduction.adoc
+++ b/docs/chapters/introduction.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Introduction
 
 The Java EE 7 platform continues the ease of development push that
@@ -49,7 +51,7 @@ http://netbeans.org/downloads/[http://netbeans.org/downloads/]. A
 snapshot of the downloads page is shown and highlights the exact
 `Download' button to be clicked.
 +
-image::images/1.1-netbeans-download.png[title="NetBeans download"]
+image::1.1-netbeans-download.png[title="NetBeans download"]
 endif::ide-netbeans[]
 +
 ifdef::server-glassfish[]

--- a/docs/chapters/jaxrs.adoc
+++ b/docs/chapters/jaxrs.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[jaxrs]]
 == View and Delete Movie (Java API for RESTful Web Services)
 
@@ -38,7 +40,7 @@ Resolve the imports.
 +
 WARNING: Make sure to pick `javax.enterprise.context.RequestScoped` class.
 +
-image::images/6.2-imports.png[title="RequestScoped import"]
+image::6.2-imports.png[title="RequestScoped import"]
 +
 . Add the following code to the class:
 +
@@ -139,7 +141,7 @@ Click on the yellow bulb in the left bar to resolve the namespace
 prefix-to-URI resolution. This needs to be completed for `h:`, `c:`,
 and `f:` prefixes.
 +
-image::images/6.6-imports.png[title="Namespace prefix imports"]
+image::6.6-imports.png[title="Namespace prefix imports"]
 +
 . Right-click on `org.javaee7.movieplex7.client' package, select
 `New', `Java Class', specify the value as `MovieBackingBean' and click
@@ -174,7 +176,7 @@ WARNING: Make sure to import `javax.enterprise.context.SessionScoped`.
 Running the project (Fn + F6 shortcut on Mac) and clicking on `Movies'
 in the left navigation bar shows the output as shown.
 +
-image::images/6.8-output.png[title="List of movies output page"]
+image::6.8-output.png[title="List of movies output page"]
 +
 The list of all the movies with a radio button next to them is
 displayed.
@@ -252,7 +254,7 @@ using the `id`, `name`, and `actors` property values.
 select a radio button next to any movie, and click on details to see the
 output as shown.
 +
-image::images/6.12-output.png[title="Movie Details page"]
+image::6.12-output.png[title="Movie Details page"]
 +
 Click on the `Back' button to select another movie.
 +
@@ -293,7 +295,7 @@ Make sure to resolve the imports.
 +
 Running the project shows the output shown.
 +
-image::images/6.14-output.png[title="Delete button"]
+image::6.14-output.png[title="Delete button"]
 +
 Select a movie and click on Delete button. This deletes the movie from
 the database and refreshes list on the page. Note that a redeploy of the

--- a/docs/chapters/jaxrs.adoc
+++ b/docs/chapters/jaxrs.adoc
@@ -1,4 +1,5 @@
 :imagesdir: ../images
+:experimental:
 
 [[jaxrs]]
 == View and Delete Movie (Java API for RESTful Web Services)
@@ -153,7 +154,7 @@ Add the following field:
 int movieId;
 +
 Add getters/setters by right-clicking on the editor pane and selecting
-`Insert Code' (Ctrl + I shortcut on Mac). Select the field and click on
+`Insert Code' (kbd:[Ctrl+I] shortcut on OSX). Select the field and click on
 `Generate'.
 +
 Add `@Named` and `@SessionScoped` class-level annotations and implements
@@ -173,7 +174,7 @@ WARNING: Make sure to import `javax.enterprise.context.SessionScoped`.
     </h:outputLink>
 ----
 +
-Running the project (Fn + F6 shortcut on Mac) and clicking on `Movies'
+Running the project (kbd:[Fn+F6] shortcut on OSX) and clicking on `Movies'
 in the left navigation bar shows the output as shown.
 +
 image::6.8-output.png[title="List of movies output page"]

--- a/docs/chapters/jms.adoc
+++ b/docs/chapters/jms.adoc
@@ -1,4 +1,5 @@
 :imagesdir: ../images
+:experimental:
 
 [[jms]]
 == Movie Points (Java Message Service)
@@ -72,7 +73,7 @@ This could be thought as conveying the customer identifier and the
 points accrued by that customer.
 +
 Generate getter/setters for this field. Right-click in the editor pane,
-select `Insert Code' (Ctrl + I shortcut on Mac), select `Getter and
+select `Insert Code' (kbd:[Ctrl+I] shortcut on OSX), select `Getter and
 Setter', select the field, and click on `Generate'.
 +
 . Add the following code to the class:

--- a/docs/chapters/jms.adoc
+++ b/docs/chapters/jms.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[jms]]
 == Movie Points (Java Message Service)
 
@@ -37,7 +39,7 @@ passivated with the request.
 +
 Resolve the imports.
 +
-image::images/8.2-imports.png[title="RequestScoped import"]
+image::8.2-imports.png[title="RequestScoped import"]
 +
 . A message to a JMS Queue is sent after the customer has bought the
 tickets. Another bean will then retrieve this message and update the
@@ -266,16 +268,16 @@ message is displayed on the screen.
 +
 . Run the project. The update page looks like as shown:
 +
-image::images/8.10-output.png[title="Points link on main page"]
+image::8.10-output.png[title="Points link on main page"]
 +
 Click on `Points' to see the output as:
 +
-image::images/8.10-output2.png[title="Points output page"]
+image::8.10-output2.png[title="Points output page"]
 +
 The output shows that the queue has 0 messages. Enter a message `1212'
 in the text box and click on `Send Message' to see the output as shown.
 +
-image::images/8.10-output3.png[title="Validation message on Points page"]
+image::8.10-output3.png[title="Validation message on Points page"]
 +
 This message is not meeting the validation criteria and so the error
 message is displayed.
@@ -283,24 +285,24 @@ message is displayed.
 Enter a message as `12,12' in the text box and click on `Send Message'
 button to see the output as:
 +
-image::images/8.10-output4.png[title="Correct input for Points page - Send Message (queue size=1)"]
+image::8.10-output4.png[title="Correct input for Points page - Send Message (queue size=1)"]
 +
 The updated count now shows that there is 1 message in the queue. Click
 on `Receive Message' button to see output as:
 +
-image::images/8.10-output5.png[title="Correct input for Points page - Receive Message (queue size=0)"]
+image::8.10-output5.png[title="Correct input for Points page - Receive Message (queue size=0)"]
 +
 The updated count now shows that the message has been consumed and the
 queue has 0 messages.
 +
 Click on `Send Message' 4 times to see the output as:
 +
-image::images/8.10-output6.png[title="Correct input for Points page - Send Message (queue size=4)"]
+image::8.10-output6.png[title="Correct input for Points page - Send Message (queue size=4)"]
 +
 The updated count now shows that the queue has 4 messages. Click on
 `Receive Message' 2 times to see the output as:
 +
-image::images/8.10-output7.png[title="Correct input for Points page - Receive Message (queue size=2)"]
+image::8.10-output7.png[title="Correct input for Points page - Receive Message (queue size=2)"]
 +
 The count is once again updated to reflect the 2 consumed and 2
 remaining messages in the queue.

--- a/docs/chapters/jsf.adoc
+++ b/docs/chapters/jsf.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[jsf]]
 == Show Booking (JavaServer Faces)
 
@@ -76,7 +78,7 @@ commandButton refers to the next view in the flow, i.e.
 Click on the yellow bulb as shown and click on the suggestion to
 add namespace prefix/URI mapping for `h:`. Repeat the same for `f:` prefix as well.
 +
-image::images/9.3-imports.png[title="Namespace prefix mapping imports"]
+image::9.3-imports.png[title="Namespace prefix mapping imports"]
 +
 . Right-click on `Source Packages', select `New', `Java Class'.
 Specify the class name as `Booking' and the package name as
@@ -368,24 +370,24 @@ which defines the flow of the pages.
 . Run the project by right clicking on the project and selecting
 `Run'. The browser shows the updated output.
 +
-image::images/9.11-output.png[title="Book a movie link on main page"]
+image::9.11-output.png[title="Book a movie link on main page"]
 +
 Click on `Book a movie' to see the page as shown.
 +
-image::images/9.11-output2.png[title="Book a movie page"]
+image::9.11-output2.png[title="Book a movie page"]
 +
 Select a movie, say `The Shiningr and click on `Pick a time' to see the
 page output as shown.
 +
-image::images/9.11-output3.png[title="Show Timings page"]
+image::9.11-output3.png[title="Show Timings page"]
 +
 Pick a time slot, say `04:00', click on `Confirm' to see the output as shown.
 +
-image::images/9.11-output4.png[title="Confirm? page"]
+image::9.11-output4.png[title="Confirm? page"]
 +
 Click on `Book' to confirm and see the output as:
 +
-image::images/9.11-output5.png[title="Reservation Confirmed page"]
+image::9.11-output5.png[title="Reservation Confirmed page"]
 +
 Feel free to enter other combinations, go back and forth in the flow and
 notice how the values in the bean are preserved.

--- a/docs/chapters/json.adoc
+++ b/docs/chapters/json.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[json]]
 == Add Movie (Java API for JSON Processing)
 
@@ -50,11 +52,11 @@ this implementation will consume a JSON representation of the resource.
 +
 Make sure to resolve imports from the appropriate package as shown.
 +
-image::images/7.2-imports.png[title="Provider import"]
+image::7.2-imports.png[title="Provider import"]
 +
 . Make the class implements `MessageBodyReader<Movie>`.
 +
-image::images/7.3-implements.png[title="Implement abstract methods for MessageBodyReader"]
+image::7.3-implements.png[title="Implement abstract methods for MessageBodyReader"]
 +
 Click on the hint (shown as yellow bulb) on the class definition and
 select `Implement all abstract methods'.
@@ -132,7 +134,7 @@ this implementation will produce a JSON representation of the resource.
 +
 Resolve the imports as shown.
 +
-image::images/7.6-imports.png[title="Provider import"]
+image::7.6-imports.png[title="Provider import"]
 +
 . Make this class implement `MessageBodyWriter` interface by adding the following code:
 [source, java]
@@ -142,7 +144,7 @@ Resolve the imports.
 +
 The IDE provide a hint to implement abstract methods as:
 +
-image::images/7.7-implements.png[title="Implement abstract methods for MessageBodyWriter"]
+image::7.7-implements.png[title="Implement abstract methods for MessageBodyWriter"]
 +
 Click on the hint (show as yellow bulb) on the class definition and
 select `Implement all abstract methods'.
@@ -230,7 +232,7 @@ then renders `movies.xhtml'.
 Click on the hint (show as yellow bulb) to resolve the namespace
 prefix/URI mapping as shown.
 +
-image::images/7.11-imports.png[title="Namespace prefix mapping imports"]
+image::7.11-imports.png[title="Namespace prefix mapping imports"]
 +
 . Add `movieName` and `actors` field to `MovieBackingBean` as:
 +
@@ -273,17 +275,17 @@ the POJO to JSON. Media type of `application/json` is specified using `MediaType
 +
 Resolve the imports as shown
 +
-image::images/7.14-imports.png[title="Entity import"]
+image::7.14-imports.png[title="Entity import"]
 +
 . Run the project to see the updated main page as:
 +
-image::images/7.15-output.png[title="New Movie button"]
+image::7.15-output.png[title="New Movie button"]
 +
 A new movie can be added by clicking on `New Movie' button.
 +
 . Enter the details as shown:
 +
-image::images/7.16-output.png[title="Add a New Movie page"]
+image::7.16-output.png[title="Add a New Movie page"]
 +
 Click on `Add' button. The `Movie Id' value has to be greater than 20
 otherwise the primary key constraint will be violated. The table
@@ -292,6 +294,6 @@ sequence; however this is not done in the application.
 +
 The updated page looks like as shown
 +
-image::images/7.16-output2.png[title="Newly added movie"]
+image::7.16-output2.png[title="Newly added movie"]
 +
 Note that the newly added movie is now displayed.

--- a/docs/chapters/revision.adoc
+++ b/docs/chapters/revision.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Revision History
 
 . Added IntelliJ IDEA specific instructions. (Jan 22, 2014)

--- a/docs/chapters/solutions.adoc
+++ b/docs/chapters/solutions.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Completed Solutions
 
 The completed solution can be downloaded from https://github.com/javaee-samples/javaee7-hol/blob/master/solution/movieplex7-solution.zip[javaee7-hol].

--- a/docs/chapters/statement.adoc
+++ b/docs/chapters/statement.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Problem Statement
 
 This hands-on lab builds a typical 3-tier Java EE 7 Web application that
@@ -7,7 +9,7 @@ existing movies. Customers can discuss the movie in a chat room. Total
 sales from each showing are calculated at the end of the day. Customers
 also accrue points for watching movies.
 
-image::images/2.0-problem-statement.png[title="Architecture diagram"]
+image::2.0-problem-statement.png[title="Architecture diagram"]
 
 This figure shows the key components of the application. The User
 Interface initiates all the flows in the application. Show Booking,
@@ -20,7 +22,7 @@ various Java technologies and web standards in their implementation. The
 following figure shows how Java EE technologies are used in different
 flows.
 
-image::images/2.0-technologies.png[title="Technologies used in the application"]
+image::2.0-technologies.png[title="Technologies used in the application"]
 
 The table below details the components and the selected technology used
 in its’ implementation.
@@ -91,7 +93,7 @@ to the editor. This keeps the code legible.
 This functionality can be accessed by right-clicking in the editor pane
 and selecting “Format” as shown.
 
-image::images/2.1-format.png[title="Format code in NetBeans"]
+image::2.1-format.png[title="Format code in NetBeans"]
 
 This functionality is also accessible using the following keyboard
 shortcuts:
@@ -115,12 +117,12 @@ not auto-import the classes. This is required to be done manually in
 order for the classes to compile. This can be fixed for each missing
 import statement by clicking on the yellow bulb shown in the side bar.
 
-image::images/2.1-server-endpoint.png[title="ServerEndpoint import"]
+image::2.1-server-endpoint.png[title="ServerEndpoint import"]
 
 Alternatively all the imports can be resolved by right-clicking on the
 editor pane and selecting ``Fix Imports'' as shown.
 
-image::images/2.1-fix-imports.png[title="Fix Imports in NetBeans"]
+image::2.1-fix-imports.png[title="Fix Imports in NetBeans"]
 
 This functionality is also accessible using the following keyboard
 shortcuts:

--- a/docs/chapters/statement.adoc
+++ b/docs/chapters/statement.adoc
@@ -1,4 +1,5 @@
 :imagesdir: ../images
+:experimental:
 
 == Problem Statement
 
@@ -98,17 +99,17 @@ image::2.1-format.png[title="Format code in NetBeans"]
 This functionality is also accessible using the following keyboard
 shortcuts:
 
-[width="50%", options="header"]
+[width="50%"]
 |===
-| Shortcut | Operating System
+|Shortcut | Operating System
 
-|Ctrl + Shift + F
-|Mac
+|kbd:[Ctrl+Shift+F]
+|OSX
 
-|Alt + Shift + F
+|kbd:[Alt+Shift+F]
 |Windows
 
-|Alt + Shift + F
+|kbd:[Alt+Shift+F]
 |Linux
 |===
 
@@ -127,18 +128,18 @@ image::2.1-fix-imports.png[title="Fix Imports in NetBeans"]
 This functionality is also accessible using the following keyboard
 shortcuts:
 
-[width="50%", options="header"]
+[width="50%"]
 |===
-| Shortcut | Operating System
+|Shortcut | Operating System
 
-| Command + Shift + I
-| Mac
+|kbd:[Command+Shift+I]
+|OSX
 
-| Ctrl + Shift + I
-| Windows
+|kbd:[Ctrl+Shift+I]
+|Windows
 
-| Ctrl + Shift + I
-| Linux
+|kbd:[Ctrl+Shift+I]
+|Linux
 |===
 
 The defaults may work in most of the cases. Choices are shown in case a

--- a/docs/chapters/statement.adoc
+++ b/docs/chapters/statement.adoc
@@ -10,7 +10,8 @@ existing movies. Customers can discuss the movie in a chat room. Total
 sales from each showing are calculated at the end of the day. Customers
 also accrue points for watching movies.
 
-image::2.0-problem-statement.png[title="Architecture diagram"]
+.Architecture diagram
+image::2.0-problem-statement.png[]
 
 This figure shows the key components of the application. The User
 Interface initiates all the flows in the application. Show Booking,
@@ -23,35 +24,36 @@ various Java technologies and web standards in their implementation. The
 following figure shows how Java EE technologies are used in different
 flows.
 
-image::2.0-technologies.png[title="Technologies used in the application"]
+.Technologies used in the application
+image::2.0-technologies.png[]
 
 The table below details the components and the selected technology used
 in its’ implementation.
 
-[cols="2,8", options="header"]
+[cols="2,8"]
 |===
-| Flow | Description
+|Flow | Description
 
-| User Interface
-| Written entirely in _JavaServer Faces_ (JSF)
+|User Interface
+|Written entirely in _JavaServer Faces_ (JSF)
 
-| Chat Room
-| Utilizes client-side JavaScript and JSON to communicate with a _WebSocket_ endpoint
+|Chat Room
+|Utilizes client-side JavaScript and JSON to communicate with a _WebSocket_ endpoint
 
-| Ticket Sales
-| Uses _Batch Applications for the Java Platform_ to calculate the total
+|Ticket Sales
+|Uses _Batch Applications for the Java Platform_ to calculate the total
 sales and persist to the database.
 
-| Add/Delete Movie
-| Implemented using RESTful Web Services. JSON is used as on-the-wire data format
+|Add/Delete Movie
+|Implemented using RESTful Web Services. JSON is used as on-the-wire data format
 
-| Movie Points
-| Uses _Java Message Service_ (JMS) to update and obtain loyalty reward
+|Movie Points
+|Uses _Java Message Service_ (JMS) to update and obtain loyalty reward
 points; an optional implementation using database technology may be
 performed
 
-| Show Booking
-| Uses lightweight _Enterprise JavaBeans_ to communicate with the database
+|Show Booking
+|Uses lightweight _Enterprise JavaBeans_ to communicate with the database
 using Java Persistence API
 |===
 
@@ -85,16 +87,19 @@ While you are copy/pasting the code from this document into NetBeans,
 here are couple of tips that will be really useful and make your
 experience enjoyable!
 
-* NetBeans provides capability to neatly format the source code
+Source Code Formatting::
+NetBeans provides capability to neatly format the source code
 following conventions. This can be done for any type of source code,
 whether its XML or Java or something else. It is highly recommended to
 use this functionality after the code is copy/pasted from this document
 to the editor. This keeps the code legible.
-
++
+--
 This functionality can be accessed by right-clicking in the editor pane
 and selecting “Format” as shown.
 
-image::2.1-format.png[title="Format code in NetBeans"]
+.Format code in NetBeans
+image::2.1-format.png[]
 
 This functionality is also accessible using the following keyboard
 shortcuts:
@@ -112,18 +117,23 @@ shortcuts:
 |kbd:[Alt+Shift+F]
 |Linux
 |===
+--
 
-* Copy/pasting the Java code from this document in NetBeans editor does
+Automatic Imports::
+Copy/pasting the Java code from this document in NetBeans editor does
 not auto-import the classes. This is required to be done manually in
 order for the classes to compile. This can be fixed for each missing
 import statement by clicking on the yellow bulb shown in the side bar.
-
-image::2.1-server-endpoint.png[title="ServerEndpoint import"]
++
+--
+.ServerEndpoint import
+image::2.1-server-endpoint.png[]
 
 Alternatively all the imports can be resolved by right-clicking on the
 editor pane and selecting ``Fix Imports'' as shown.
 
-image::2.1-fix-imports.png[title="Fix Imports in NetBeans"]
+.Fix Imports in NetBeans
+image::2.1-fix-imports.png[]
 
 This functionality is also accessible using the following keyboard
 shortcuts:
@@ -146,6 +156,7 @@ The defaults may work in most of the cases. Choices are shown in case a
 class is available to import from multiple packages. If multiple
 packages are available then specific packages to import from are clearly
 marked in the document.
+--
 
 === Estimated Time
 
@@ -162,25 +173,31 @@ pre-requisite for <<json>>.
 
 Here is an approximate time estimate for each section:
 
-[cols="4,2" options="header"]
+[cols="4,2"]
 |===
-| Section Title | Estimated Time
+|Section Title |Estimated Time
 
-| <<walk-through>> | 15 - 30 mins
+|<<walk-through>>
+|15 - 30 mins
 
-| <<websocket>> | 30 - 45 mins
+|<<websocket>>
+|30 - 45 mins
 
-| <<batch>> | 30 - 45 mins
+|<<batch>>
+|30 - 45 mins
 
-| <<jaxrs>> | 30 - 45 mins
+|<<jaxrs>>
+|30 - 45 mins
 
-| <<json>> | 30 - 45 mins
+|<<json>>
+|30 - 45 mins
 
-| <<jms>> | 30 - 45 mins
+|<<jms>>
+|30 - 45 mins
 
-| <<jsf>> | 30 - 45 mins
+|<<jsf>>
+|30 - 45 mins
 |===
-
 
 The listed time for each section is only an estimate and by no means
 restrict you within that. These sections have been completed in much
@@ -189,4 +206,3 @@ shorter time, and you can do it too!
 TIP: The listed time for each section also allows you to create a custom
 version of the lab depending upon your target audience and available
 time.
-

--- a/docs/chapters/todo.adoc
+++ b/docs/chapters/todo.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == TODO
 
 .  Add the following use cases:

--- a/docs/chapters/troubleshooting.adoc
+++ b/docs/chapters/troubleshooting.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 == Troubleshooting
 
 [qanda]
@@ -17,12 +19,12 @@ node, and select
 ifdef::server-glassfish[]
 `View Domain Server Log'.
 +
-image::images/netbeans-view-log.png[title="View GlassFish server log in NetBeans"]
+image::netbeans-view-log.png[title="View GlassFish server log in NetBeans"]
 endif::server-glassfish[]
 ifdef::server-wildfly[]
 `View Server Log'.
 +
-image::images/11-wildfly-server-log.png[title="View WildFly server log in NetBeans"]
+image::11-wildfly-server-log.png[title="View WildFly server log in NetBeans"]
 endif::server-wildfly[]
 +
 In addition, the web-based administration console can be seen by clicking on

--- a/docs/chapters/walkthrough.adoc
+++ b/docs/chapters/walkthrough.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[walk-through]]
 == Walk-through of Sample Application
 
@@ -16,7 +18,7 @@ content there.
 unzipped directory, and click on `Open Project'. The project structure
 is shown.
 +
-image::images/3.2-project-structure.png[title="Project structure in NetBeans"]
+image::3.2-project-structure.png[title="Project structure in NetBeans"]
 +
 . Maven Coordinates: Expand `Project Files' and double click on
 `pom.xml'. In the `pom.xml', the Java EE 7 API is specified as a
@@ -65,7 +67,7 @@ Platform, can be deployed on Web Profile.
 By default, NetBeans opens the file in Design View. Click on `Source' tab
 to view the XML source.
 +
-image::images/3.2-persistence-xml.png[title="persistence.xml"]
+image::3.2-persistence-xml.png[title="persistence.xml"]
 +
 It looks like:
 +
@@ -134,7 +136,7 @@ endif::server-glassfish[]
 Clicking back and forth between `Design' and `Source' view may prompt
 the error shown below:
 +
-image::images/3.4-missing-server.png[title="Missing server error from persistence.xml"]
+image::3.4-missing-server.png[title="Missing server error from persistence.xml"]
 +
 This will get resolved when we run the application. Click on `OK' to
 dismiss the dialog.
@@ -192,7 +194,7 @@ URL, the scripts may be loaded from outside the WAR file as well.
 Feel free to open `create.sql', `drop.sql' and `load.sql' and read
 through the SQL scripts. The database schema is shown.
 +
-image::images/3.5-schema.png[title="Database schema"]
+image::3.5-schema.png[title="Database schema"]
 +
 This folder also contains `sales.csv' which carries some comma-separated
 data, and is used later in the application.
@@ -281,15 +283,15 @@ During the first run, the IDE will ask you to select a deployment server.
 ifdef::server-wildfly[]
 Choose the configured WildFly server and click on `OK'.
 +
-image::images/3.6-wildfly-server.png[title="WildFly deployment server"]
+image::3.6-wildfly-server.png[title="WildFly deployment server"]
 endif::server-wildfly[]
 ifdef::server-glassfish[]
 Choose the configured GlassFish server and click on `OK'.
 +
-image::images/3.6-glassfish-server.png[title="GlassFish server"]
+image::3.6-glassfish-server.png[title="GlassFish server"]
 endif::server-glassfish[]
 +
 The output looks like as shown.
 +
-image::images/3.8-first-page.png[title="Application main page"]
+image::3.8-first-page.png[title="Application main page"]
 

--- a/docs/chapters/walkthrough.adoc
+++ b/docs/chapters/walkthrough.adoc
@@ -18,14 +18,14 @@ content there.
 unzipped directory, and click on `Open Project'. The project structure
 is shown.
 +
---
 .Project structure in NetBeans
 image::3.2-project-structure.png[]
 
 . Maven Coordinates: Expand `Project Files' and double click on
 `pom.xml'. In the `pom.xml', the Java EE 7 API is specified as a
 <dependency>:
-
++
+--
 [source,xml]
 <dependencies>
     <dependency>

--- a/docs/chapters/walkthrough.adoc
+++ b/docs/chapters/walkthrough.adoc
@@ -13,17 +13,19 @@ performed to provide an understanding of the application architecture.
 https://github.com/javaee-samples/javaee7-hol/blob/master/starting-template/movieplex7-starting-template.zip?raw=true[movieplex7-starting-template.zip]
 and unzip. This will create a `movieplex7' directory and unzips all the
 content there.
-+
+
 . In NetBeans IDE, select `File', `Open Project', select the
 unzipped directory, and click on `Open Project'. The project structure
 is shown.
 +
-image::3.2-project-structure.png[title="Project structure in NetBeans"]
-+
+--
+.Project structure in NetBeans
+image::3.2-project-structure.png[]
+
 . Maven Coordinates: Expand `Project Files' and double click on
 `pom.xml'. In the `pom.xml', the Java EE 7 API is specified as a
 <dependency>:
-+
+
 [source,xml]
 <dependencies>
     <dependency>
@@ -33,10 +35,10 @@ image::3.2-project-structure.png[title="Project structure in NetBeans"]
         <scope>provided</scope>
     </dependency>
 </dependencies>
-+
+
 This will ensure that Java EE 7 APIs are retrieved from the central
 Maven repository.
-+
+
 [NOTE]
 =================
 The Java EE 6 platform introduced the notion of `profiles'. A profile is
@@ -57,20 +59,23 @@ endif::server-glassfish[]
 ifdef::server-wildfly[]
 WildFly can be started in Full Platform or Web Profile.
 endif::server-wildfly[]
-+
+
 IMPORTANT: This lab requires Full Platform download. All technologies used in this
 lab, except Java Message Service and Batch Applications for the Java
 Platform, can be deployed on Web Profile.
-+
+--
+
 . *Default Data Source*: Expand `Other Sources',
 `src/main/resources', `META-INF', and double-click on `persistence.xml'.
 By default, NetBeans opens the file in Design View. Click on `Source' tab
 to view the XML source.
 +
-image::3.2-persistence-xml.png[title="persistence.xml"]
-+
+--
+.persistence.xml
+image::3.2-persistence-xml.png[]
+
 It looks like:
-+
+
 [source,xml]
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence
@@ -108,23 +113,23 @@ It looks like:
         </properties>
     </persistence-unit>
 </persistence>
-+
+
 Notice `<jta-data-source>` is commented out, i.e. no data source element
 is specified. This element identifies the JDBC resource to connect to in
 the runtime environment of the underlying application server.
-+
+
 The Java EE 7 platform defines a new default data source that must be
 provided by the runtime. This pre-configured data source is accessible
 under the JNDI name
-+
+
 [source,java]
 java:comp/DefaultDataSource
-+
+
 The JPA 2.1 specification says if neither `jta-data-source` nor
 `non-jta-data-source` elements are specified, the deployer must specify a
 JTA data source or the default JTA data source must be provided by the
 container.
-+
+
 ifdef::server-wildfly[]
 For WildFly 8, the default data source is bound to the JDBC resource `what name`.
 endif::server-wildfly[]
@@ -132,15 +137,17 @@ ifdef::server-glassfish[]
 For GlassFish 4, the default data source is bound to the JDBC resource
 `jdbc/__default`.
 endif::server-glassfish[]
-+
+
 Clicking back and forth between `Design' and `Source' view may prompt
 the error shown below:
-+
-image::3.4-missing-server.png[title="Missing server error from persistence.xml"]
-+
+
+.Missing server error from persistence.xml
+image::3.4-missing-server.png[]
+
 This will get resolved when we run the application. Click on `OK' to
 dismiss the dialog.
-+
+--
+
 . *Schema Generation:* JPA 2.1 defines a new set of
 `javax.persistence.schema-generation.*` properties that can be used to
 generate database artifacts like tables, indexes, and constraints in a
@@ -150,116 +157,122 @@ or as part of `EntityManagerFactory` creation. This feature will allow
 your JPA domain object model to be directly generated in a database. The
 generated schema may need to be tuned for actual production environment.
 +
+--
 The ``persistence.xml'' in the application has the following
 `javax.persistence.schema-generation.*` properties. Their meaning and
 possible values are explained:
-+
-[options="header"]
+
 |===
 |Property |Meaning |Values
 
-| `javax.persistence.schema-generation.database.action`
-| Specifies the action to be taken by the persistence provider with regard
+|`javax.persistence.schema-generation.database.action`
+|Specifies the action to be taken by the persistence provider with regard
 to the database artifacts.
-| `none`, `create`, `drop-and-create`, `drop`
+|`none`, `create`, `drop-and-create`, `drop`
 
-| `javax.persistence.schema-generation.create-source`
- `javax.persistence.schema-generation.drop-source`
-| Specifies whether the creation or deletion of database artifacts is to
+|`javax.persistence.schema-generation.create-source`
+`javax.persistence.schema-generation.drop-source`
+|Specifies whether the creation or deletion of database artifacts is to
 occur on the basis of the object/relational mapping metadata, DDL
 script, or a combination of the two.
-| `metadata`, `script`, `metadata-then-script`, `script-then-metadata`
+|`metadata`, `script`, `metadata-then-script`, `script-then-metadata`
 
-| `javax.persistence.schema-generation.create-script-source`
- `javax.persistence.schema-generation.drop-script-source`
-| Specifies a `java.IO.Reader` configured for reading of the SQL script or a
+|`javax.persistence.schema-generation.create-script-source`
+`javax.persistence.schema-generation.drop-script-source`
+|Specifies a `java.IO.Reader` configured for reading of the SQL script or a
 string designating a file URL for the SQL script to create or delete
 database artifacts.
 |
 
-| `javax.persistence.sql-load-script-source`
-| Specifies a `java.IO.Reader` configured for reading of the SQL load script
+|`javax.persistence.sql-load-script-source`
+|Specifies a `java.IO.Reader` configured for reading of the SQL load script
 for database initialization or a string designating a file URL for the
 script.
 |
 |===
-+
+
 Refer to the http://jcp.org/en/jsr/detail?id=338[JPA 2.1 Specification]
 for a complete understanding of these properties.
-+
+
 In the application, the scripts are bundled in the WAR file in
 `META-INF' directory. As the location of these scripts is specified as a
 URL, the scripts may be loaded from outside the WAR file as well.
-+
+
 Feel free to open `create.sql', `drop.sql' and `load.sql' and read
 through the SQL scripts. The database schema is shown.
-+
-image::3.5-schema.png[title="Database schema"]
-+
+
+.Database schema
+image::3.5-schema.png[]
+
 This folder also contains `sales.csv' which carries some comma-separated
 data, and is used later in the application.
-+
+--
+
 . *JPA entities, Stateless EJBs, and REST endpoints*: Expand `Source
 Packages'. The package `org.javaee7.movieplex7.entities` contains the
 JPA entities corresponding to the database table definitions. Each JPA
 entity has several convenient `@NamedQuery` defined and uses Bean
 Validation constraints to enforce validation.
 +
+--
 The package `org.javaee7.movieplex7.rest` contains stateless EJBs
 corresponding to different JPA entities.
-+
+
 Each EJB has methods to perform CRUD operations on the JPA entity and
 convenience query methods. Each EJB is also EL-injectable (@Named) and
 published as a REST endpoint (@Path). The AplicationConfig class defines
 the base path of REST endpoint. The path for the REST endpoint is the
 same as the JPA entity class name.
-+
+
 The mapping between JPA entity classes, EJB classes, and the URI of the
 corresponding REST endpoint is shown.
-+
-[options="header"]
+
+[cols="1m,1m,1e"]
 |===
-| JPA Entity Class | EJB Class | RESTful Path
+|JPA Entity Class |EJB Class |RESTful Path
 
-| `Movie`
-| `MovieFacadeREST`
-| /webresources/movie
+|Movie
+|MovieFacadeREST
+|/webresources/movie
 
-| `Sales`
-| `SalesFacadeREST`
-| /webresources/sales
+|Sales
+|SalesFacadeREST
+|/webresources/sales
 
-| `ShowTiming`
-| `ShowTimingFacadeREST`
-| /webresources/showtiming
+|ShowTiming
+|ShowTimingFacadeREST
+|/webresources/showtiming
 
-| `Theater`
-| `TheaterFacadeREST`
-| /webresources/theater
+|Theater
+|TheaterFacadeREST
+|/webresources/theater
 
-| `Timeslot`
-| `TimeslotFacadeREST`
-| /webresources/timeslot
+|Timeslot
+|TimeslotFacadeREST
+|/webresources/timeslot
 |===
-+
+
 Feel free to browse through the code.
-+
+--
+
 . *JSF pages*: `WEB-INF/template.xhtml' defines the template of the
 web page and has a header, left navigation bar, and a main content
 section. `index.xhtml' uses this template and the EJBs to display the
 number of movies and theaters.
 +
+--
 Java EE 7 enables CDI discovery of beans by default. No `beans.xml' is
 required in `WEB-INF'. This allows all beans with bean defining
 annotation, i.e. either a bean with an explicit CDI scope or EJBs to be
 available for injection.
-+
+
 Note, `template.xhtml' is in `WEB-INF' folder as it allows the template
 to be accessible from the pages bundled with the application only. If it
 were bundled with rest of the pages then it would be accessible outside
 the application and thus allowing other external pages to use it as
 well.
-+
+--
+
 . *Run the sample*: Right-click on the project and select `Run'.
 This will download all the maven dependencies on your machine, build a
 WAR file, deploy on 
@@ -274,24 +287,28 @@ http://localhost:8080/movieplex7[localhost:8080/movieplex7] in the
 default browser configured in NetBeans. Note that this could take a
 while if you have never built a Maven application on your machine.
 +
+--
 TIP: The project will show red squiggly lines in the source code indicating
 that the classes cannot be resolved. This is expected before the
 dependencies are downloaded. However these references will be resolved
 correctly after the dependencies are downloaded during project building.
-+
+
 During the first run, the IDE will ask you to select a deployment server.
 ifdef::server-wildfly[]
 Choose the configured WildFly server and click on `OK'.
-+
-image::3.6-wildfly-server.png[title="WildFly deployment server"]
+
+.WildFly deployment server
+image::3.6-wildfly-server.png[]
 endif::server-wildfly[]
 ifdef::server-glassfish[]
 Choose the configured GlassFish server and click on `OK'.
-+
-image::3.6-glassfish-server.png[title="GlassFish server"]
-endif::server-glassfish[]
-+
-The output looks like as shown.
-+
-image::3.8-first-page.png[title="Application main page"]
 
+.GlassFish server
+image::3.6-glassfish-server.png[]
+endif::server-glassfish[]
+
+The output looks like as shown.
+
+.Application main page
+image::3.8-first-page.png[]
+--

--- a/docs/chapters/websocket.adoc
+++ b/docs/chapters/websocket.adoc
@@ -1,3 +1,5 @@
+:imagesdir: ../images
+
 [[websocket]]
 == Chat Room (Java API for WebSocket)
 
@@ -80,7 +82,7 @@ Windows).
 +
 WARNING: Make sure to pick `java.websocket.Session` for resolving imports. This is not the default option shown by NetBeans.
 +
-image::images/4.2-imports.png[title="javax.websocket.Session import"]
+image::4.2-imports.png[title="javax.websocket.Session import"]
 +
 Right-click again in the editor pane and select `Format' to format your
 code.
@@ -94,7 +96,7 @@ code.
 `WEB-INF', select `template.xhtml', and click on `Select File'. Click on
 `Finish'.
 +
-image::images/4.4-template.png[title="Choose template"]
+image::4.4-template.png[title="Choose template"]
 +
 In this file, remove <ui:define> sections where name attribute value is
 `top' and `left'. These sections are inherited from the template.
@@ -264,14 +266,14 @@ allows the links in the left navigation bar to be fully-qualified URLs.
 `Run'. The browser shows
 http://localhost:8080/movieplex7[localhost:8080/movieplex7].
 +
-image::images/4.6-chatroom.png[title="Chatroom link on main page"]
+image::4.6-chatroom.png[title="Chatroom link on main page"]
 +
 Click on `Chat Room' to see the output.
 +
 The `CONNECTED' status message is shown and indicates that the WebSocket
 connection with the endpoint is established.
 +
-image::images/4.8-chatroom.png[title="Chatroom output"]
+image::4.8-chatroom.png[title="Chatroom output"]
 +
 Please make sure your browser supports WebSocket in order for this page
 to show up successfully. Chrome 14.0+, Firefox 11.0+, Safari 6.0+, and
@@ -283,7 +285,7 @@ Open the URI http://localhost:8080/movieplex7[localhost:8080/movieplex7]
 in another browser window. Enter `Duke' in the text box in the first
 browser and click `Join'.
 +
-image::images/4.8-chatroom-joined.png[title="Chatroom with single user"]
+image::4.8-chatroom-joined.png[title="Chatroom with single user"]
 +
 Notice that the user list and the status message in both the browsers
 gets updated. Enter `James' in the text box of the second browser and
@@ -294,7 +296,7 @@ browser and click on `Send' to send the message.
 The output from two different browsers after the initial greeting looks
 like as shown.
 +
-image::images/4.8-chatroom-two-browsers.png[title="Chatroom with two users"]
+image::4.8-chatroom-two-browsers.png[title="Chatroom with two users"]
 +
 Here it shows output from Chrome on the top and Firefox on the bottom.
 +

--- a/docs/chapters/websocket.adoc
+++ b/docs/chapters/websocket.adoc
@@ -1,4 +1,5 @@
 :imagesdir: ../images
+:experimental:
 
 [[websocket]]
 == Chat Room (Java API for WebSocket)
@@ -77,7 +78,7 @@ connection. The method implementation transmits the received text message to
 all clients connected to this endpoint.
 +
 Resolve the imports by right-clicking in the editor and selecting `Fix
-Imports' or (Command + Shift + I shortcut on Mac or Ctrl + Shift + I on
+Imports' or (kbd:[Command+Shift+I] shortcut on OSX or kbd:[Ctrl+Shift+I] on
 Windows).
 +
 WARNING: Make sure to pick `java.websocket.Session` for resolving imports. This is not the default option shown by NetBeans.

--- a/docs/convert.sh
+++ b/docs/convert.sh
@@ -10,14 +10,19 @@
 #
 # ...where the first argument is a comma-delimited list of formats
 
+# Program paths
+ASCIIDOCTOR=asciidoctor
+FOPUB=~/tools/asciidoctor-fopub/fopub
+ASCIIDOCTOR_PDF=~/tools/asciidoctor-pdf/bin/asciidoctor-pdf
+
+# File names
 MASTER_ADOC=javaee7-hol.adoc
 MASTER_DOCBOOK=${MASTER_ADOC/.adoc/.xml}
-ASCIIDOCTOR=asciidoctor
-#FOPUB=~/tools/asciidoctor-fopub/fopub
-#ASCIIDOCTOR_PDF=~/tools/asciidoctor-pdf/bin/asciidoctor-pdf
-FOPUB=~/projects/asciidoctor/fopub/fopub
-ASCIIDOCTOR_PDF=~/projects/asciidoctor/asciidoctor-pdf/bin/asciidoctor-pdf
 
+# Command options
+SHARED_OPTIONS='-a numbered -a experimental -a imagesdir=images'
+
+# Formats
 if [ ! -z $1 ]; then
   read -a FORMATS <<<$(IFS=','; echo $1)
 else
@@ -29,16 +34,16 @@ fi
 for f in ${FORMATS[*]}; do
   if [ $f == 'html' ]; then
     echo "Converting to HTML ..."
-    $ASCIIDOCTOR -v -a numbered -a imagesdir=images $MASTER_ADOC
+    $ASCIIDOCTOR -v $SHARED_OPTIONS $MASTER_ADOC
   elif [ $f == 'docbook' ]; then
     echo "Converting to DocBook ..."
-    $ASCIIDOCTOR -b docbook -a numbered -a imagesdir=images $MASTER_ADOC
+    $ASCIIDOCTOR -b docbook $SHARED_OPTIONS $MASTER_ADOC
   elif [ $f == 'fopdf' ]; then
     echo "Converting to FO-PDF ..."
     $FOPUB $MASTER_DOCBOOK
   elif [ $f == 'pdf' ]; then
     echo "Converting to PDF ..."
-    $ASCIIDOCTOR_PDF -a numbered -a imagesdir=images $MASTER_ADOC
+    $ASCIIDOCTOR_PDF $SHARED_OPTIONS $MASTER_ADOC
   fi
 done
 

--- a/docs/convert.sh
+++ b/docs/convert.sh
@@ -14,13 +14,15 @@
 ASCIIDOCTOR=asciidoctor
 FOPUB=~/tools/asciidoctor-fopub/fopub
 ASCIIDOCTOR_PDF=~/tools/asciidoctor-pdf/bin/asciidoctor-pdf
+#FOPUB=~/projects/asciidoctor/fopub/fopub
+#ASCIIDOCTOR_PDF=~/projects/asciidoctor/asciidoctor-pdf/bin/asciidoctor-pdf
 
 # File names
 MASTER_ADOC=javaee7-hol.adoc
 MASTER_DOCBOOK=${MASTER_ADOC/.adoc/.xml}
 
 # Command options
-SHARED_OPTIONS='-a numbered -a experimental -a imagesdir=images'
+SHARED_OPTIONS='-a numbered -a experimental -a source-highlighter=coderay -a imagesdir=images'
 
 # Formats
 if [ ! -z $1 ]; then

--- a/docs/convert.sh
+++ b/docs/convert.sh
@@ -1,13 +1,45 @@
-echo "Converting to HTML ..."
-#asciidoctor -a toc -a numbered javaee7-hol.adoc
-asciidoctor -v -a toc -a numbered javaee7-hol.adoc
-echo "done"
+#!/bin/bash
 
-echo "Converting to DocBook ..."
-asciidoctor -b docbook -a toc -a numbered -d book javaee7-hol.adoc
-echo "done"
+# Run using:
+#
+# ./convert.sh
+#
+# or
+#
+# ./convert.sh html,pdf
+#
+# ...where the first argument is a comma-delimited list of formats
 
-echo "Converting to PDF ..."
-~/tools/asciidoctor-fopub/fopub javaee7-hol.xml
-echo "done"
+MASTER_ADOC=javaee7-hol.adoc
+MASTER_DOCBOOK=${MASTER_ADOC/.adoc/.xml}
+ASCIIDOCTOR=asciidoctor
+#FOPUB=~/tools/asciidoctor-fopub/fopub
+#ASCIIDOCTOR_PDF=~/tools/asciidoctor-pdf/bin/asciidoctor-pdf
+FOPUB=~/projects/asciidoctor/fopub/fopub
+ASCIIDOCTOR_PDF=~/projects/asciidoctor/asciidoctor-pdf/bin/asciidoctor-pdf
 
+if [ ! -z $1 ]; then
+  read -a FORMATS <<<$(IFS=','; echo $1)
+else
+  FORMATS=(html
+docbook
+fopdf)
+fi
+
+for f in ${FORMATS[*]}; do
+  if [ $f == 'html' ]; then
+    echo "Converting to HTML ..."
+    $ASCIIDOCTOR -v -a numbered -a imagesdir=images $MASTER_ADOC
+  elif [ $f == 'docbook' ]; then
+    echo "Converting to DocBook ..."
+    $ASCIIDOCTOR -b docbook -a numbered -a imagesdir=images $MASTER_ADOC
+  elif [ $f == 'fopdf' ]; then
+    echo "Converting to FO-PDF ..."
+    $FOPUB $MASTER_DOCBOOK
+  elif [ $f == 'pdf' ]; then
+    echo "Converting to PDF ..."
+    $ASCIIDOCTOR_PDF -a numbered -a imagesdir=images $MASTER_ADOC
+  fi
+done
+
+exit 0

--- a/docs/javaee7-hol.adoc
+++ b/docs/javaee7-hol.adoc
@@ -1,6 +1,7 @@
 = Java EE 7 Hands-on Lab
 Arun Gupta <arungupta@redhat.com>
 v2.0, Jan 28, 2014
+:doctype: book
 :toc:
 :toclevels: 3
 :ide-netbeans: true


### PR DESCRIPTION
Summary of changes:
- Reworked the convert.sh script to allow the formats to be specified (defaults to html,docbook,fopdf)
- Configured image paths so previews work when viewing / rendering an individual chapter
- Put the UI macros to use (keybinding, button and menu) (requires setting the `experimental` attribute)
- Demo the use of open block as a content container (like a div) to simplify lists with complex content
- Remove unnecessary option="header" attribute on tables (Asciidoctor works it out by convention)
- Configure syntax highlighting
- Additional minor cleanups, grammar and spelling corrections

Best practices regarding images:
- You should not hardcode the path to the image. Instead, the image path should be relative to the "image catalog", which can be configured on a per-document or per-build basis.
- Titles for block (standalone) images should be specified above the macro
